### PR TITLE
Cinematic block entrances and syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,12 +101,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -114,6 +132,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -360,6 +384,7 @@ dependencies = [
  "pulldown-cmark",
  "ratatui",
  "serde",
+ "syntect",
  "toml",
 ]
 
@@ -456,8 +481,19 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -743,6 +779,12 @@ checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.11.0",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1047,6 +1089,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1169,15 @@ name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quote"
@@ -1309,6 +1373,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,6 +1561,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex 0.16.2",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "terminfo"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,7 +1611,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bitflags 2.11.0",
- "fancy-regex",
+ "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
  "fixedbitset",
@@ -1597,12 +1691,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1610,6 +1706,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "toml"
@@ -1734,6 +1840,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1934,6 +2050,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2046,6 +2171,15 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ toml = "1"
 serde = { version = "1", features = ["derive"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif"] }
 base64 = "0.22"
+syntect = { version = "5", default-features = false, features = ["default-fancy"] }
 
 [profile.release]
 strip = true

--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@ Terminal presentations with style.
 
 A tiny, single-binary presentation tool written in Rust. Render Markdown slides in your terminal with animated mathematical backgrounds, a hacker aesthetic, progressive bullet reveal, column layouts, and a full presenter mode.
 
-**1.1 MB binary. No server. No dependencies. Just `deck talk.md`.**
+**~3 MB binary. No server. No dependencies. Just `deck talk.md`.**
 
 ## Features
 
 - **Markdown slides** with TOML frontmatter, separated by `---`
+- **Syntax highlighting** - ~50 languages via syntect (`base16-ocean.dark` theme)
+- **Cinematic block entrances** - every element animates onto the slide:
+  - H1 headings **decrypt** from glitch characters (`░▒▓█@#$` → text)
+  - H2+ headings **slide in** left-to-right
+  - Code blocks **typewrite** line-by-line with a blinking `▌` cursor
+  - Bullet points **cascade** with staggered timing
+  - Paragraphs and images **dissolve** in
 - **Big ASCII text** for `# H1` headings
 - **Progressive reveal** - bullet points appear one at a time
 - **Column layouts** - side-by-side content with `::: columns` syntax
@@ -17,7 +24,7 @@ A tiny, single-binary presentation tool written in Rust. Render Markdown slides 
 - **Presenter mode** (`p`) - current slide + next preview + notes + timer
 - **Dual-screen mode** - `--present` on your laptop, `--follow` on the projector
 - **10 animated backgrounds** - mathematical screensavers for your title slide
-- **Slide transitions** - glitch and fade effects
+- **Slide transitions** - glitch, fade, wipe, and dissolve effects
 - **4 themes** - `hacker` (default), `corporate`, `catppuccin`, and `minimal`
 - **Vim-style navigation** - arrow keys, hjkl, go-to-slide
 
@@ -137,6 +144,35 @@ Use HTML comments to configure individual slides:
 | `orbit` | Particles on tilted elliptical orbits | Circling dots with trails |
 
 Set in frontmatter (applies to first slide) or per-slide with `<!-- background: name -->`.
+
+## Block Entrances
+
+Every block on a slide gets a cinematic entrance animation when the slide first appears. No configuration needed — effects are assigned automatically by block type.
+
+| Block | Effect | Duration |
+|-------|--------|----------|
+| `# H1` heading | **Decrypt** — glitch characters resolve into ASCII art | 600ms |
+| `## H2+` heading | **Slide-in** — text reveals left-to-right | 300ms |
+| Code block | **Typewriter** — syntax-highlighted lines type one-by-one with `▌` cursor | ~50ms per line |
+| Bullet item | **Cascade** — staggered fade-in, 100ms delay between items | 200ms each |
+| Paragraph | **Fade-in** — smoothstep dissolve | 250ms |
+| Image | **Fade-in** — smoothstep dissolve | 300ms |
+
+Entrances replay each time you navigate to a slide. The frame rate automatically elevates to 60fps while animations are active, then drops back to save CPU.
+
+## Syntax Highlighting
+
+Code blocks are syntax-highlighted for ~50 languages using [syntect](https://github.com/trishume/syntect) with the `base16-ocean.dark` theme. The language is detected from the fenced code block tag:
+
+````markdown
+```rust
+fn main() {
+    println!("highlighted!");
+}
+```
+````
+
+Combined with the typewriter entrance, code blocks type themselves out in full color — great for walking an audience through code step by step.
 
 ## Keyboard Shortcuts
 

--- a/examples/demo.md
+++ b/examples/demo.md
@@ -57,12 +57,23 @@ or contrasting ideas.
 ## Code Blocks
 
 ```rust
-fn main() {
-    println!("Hello from deck!");
+use std::collections::HashMap;
+
+fn fibonacci(n: u64) -> u64 {
+    let mut cache: HashMap<u64, u64> = HashMap::new();
+    fib_cached(n, &mut cache)
+}
+
+fn fib_cached(n: u64, cache: &mut HashMap<u64, u64>) -> u64 {
+    if n <= 1 { return n; }
+    if let Some(&val) = cache.get(&n) { return val; }
+    let result = fib_cached(n - 1, cache) + fib_cached(n - 2, cache);
+    cache.insert(n, result);
+    result
 }
 ```
 
-Syntax-highlighted code with clean borders.
+Syntax-highlighted with animated typewriter entrance.
 
 ---
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,6 +9,8 @@ use ratatui::{
 };
 
 use crate::background;
+use crate::entrance::EntranceTracker;
+use crate::highlight::Highlighter;
 use crate::image_renderer::{DeferredImage, ImageCache, ImageProtocol};
 use crate::input::{map_key, Action};
 use crate::markdown::Block;
@@ -42,6 +44,8 @@ pub struct App {
     pub image_cache: ImageCache,
     pub deferred_images: Vec<DeferredImage>,
     pub base_dir: PathBuf,
+    pub highlighter: Highlighter,
+    pub entrances: EntranceTracker,
 }
 
 impl App {
@@ -74,6 +78,8 @@ impl App {
             image_cache: ImageCache::new(),
             deferred_images: Vec::new(),
             base_dir,
+            highlighter: Highlighter::new(),
+            entrances: EntranceTracker::new(),
         }
     }
 
@@ -92,6 +98,7 @@ impl App {
 
     pub fn draw(&mut self, frame: &mut Frame) {
         self.deferred_images.clear();
+        self.entrances.on_slide_change(self.slide_index);
 
         let area = frame.area();
 
@@ -108,6 +115,9 @@ impl App {
             image_cache: &mut self.image_cache,
             deferred: &mut self.deferred_images,
             base_dir: &self.base_dir,
+            highlighter: &self.highlighter,
+            entrances: &mut self.entrances,
+            slide_index: self.slide_index,
         };
 
         // Render slide

--- a/src/entrance.rs
+++ b/src/entrance.rs
@@ -1,0 +1,273 @@
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use ratatui::{layout::Rect, style::Style, Frame};
+
+use crate::theme::Theme;
+
+/// What kind of entrance animation a block gets.
+#[derive(Clone, Debug)]
+pub enum EntranceKind {
+    /// H1 headings: glitch characters resolve into real text
+    Decrypt,
+    /// H2+ headings: characters appear left-to-right
+    SlideIn,
+    /// Bullet items: staggered cascade with delay per item
+    Cascade,
+    /// Code blocks: line-by-line typing with cursor
+    Typewriter,
+    /// Paragraphs, images: cell-by-cell dissolve
+    FadeIn,
+}
+
+/// Tracks animation progress for a single block entrance.
+pub struct EntranceState {
+    pub kind: EntranceKind,
+    pub started: Instant,
+    pub duration: Duration,
+}
+
+impl EntranceState {
+    pub fn new(kind: EntranceKind, duration: Duration) -> Self {
+        Self {
+            kind,
+            started: Instant::now(),
+            duration,
+        }
+    }
+
+    /// Animation progress 0.0..=1.0
+    pub fn progress(&self) -> f64 {
+        if self.duration.is_zero() {
+            return 1.0;
+        }
+        (self.started.elapsed().as_secs_f64() / self.duration.as_secs_f64()).min(1.0)
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.started.elapsed() >= self.duration
+    }
+}
+
+/// Tracks per-block entrance animations across frames.
+/// Keyed by (slide_index, block_index).
+pub struct EntranceTracker {
+    states: HashMap<(usize, usize), EntranceState>,
+    current_slide: usize,
+}
+
+impl EntranceTracker {
+    pub fn new() -> Self {
+        Self {
+            states: HashMap::new(),
+            current_slide: usize::MAX,
+        }
+    }
+
+    /// Called when a slide changes — purges old animations.
+    pub fn on_slide_change(&mut self, slide: usize) {
+        if slide != self.current_slide {
+            self.states.clear();
+            self.current_slide = slide;
+        }
+    }
+
+    /// Get entrance state for a block, creating a new animation if first seen.
+    /// Returns None if the animation is already finished (no need to apply effects).
+    pub fn get_or_start(
+        &mut self,
+        slide: usize,
+        block_idx: usize,
+        kind: EntranceKind,
+        duration: Duration,
+    ) -> Option<&EntranceState> {
+        let key = (slide, block_idx);
+        let state = self
+            .states
+            .entry(key)
+            .or_insert_with(|| EntranceState::new(kind, duration));
+        if state.is_done() {
+            None
+        } else {
+            Some(state)
+        }
+    }
+
+    /// True if any animation is still running (drives 60fps frame rate).
+    pub fn has_active(&self) -> bool {
+        self.states.values().any(|s| !s.is_done())
+    }
+}
+
+// ── Glitch character set (shared with transition.rs) ─────────────
+
+const GLITCH_CHARS: &[char] = &[
+    '!', '@', '#', '$', '%', '^', '&', '*', '<', '>', '{', '}', '[', ']', '|', '/', '\\', '~', '░',
+    '▒', '▓', '█', '▄', '▀', '▌', '▐',
+];
+
+// ── Simple RNG (same xorshift as transition.rs) ──────────────────
+
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+    fn next_f64(&mut self) -> f64 {
+        (self.next() % 10000) as f64 / 10000.0
+    }
+}
+
+// ── Entrance effect implementations ──────────────────────────────
+
+/// Decrypt effect: replace non-empty cells with glitch chars, resolving over time.
+pub fn apply_decrypt(frame: &mut Frame, rect: Rect, progress: f64, theme: &Theme) {
+    let buf = frame.buffer_mut();
+    // Seed from rect position for deterministic pattern per frame
+    let mut rng = Rng::new(progress.to_bits() ^ (rect.x as u64 * 7919 + rect.y as u64 * 104729));
+
+    for y in rect.y..rect.y + rect.height {
+        for x in rect.x..rect.x + rect.width {
+            if rng.next_f64() > progress {
+                if let Some(cell) = buf.cell_mut((x, y)) {
+                    let sym = cell.symbol().to_string();
+                    if sym != " " {
+                        let ch = GLITCH_CHARS[rng.next() as usize % GLITCH_CHARS.len()];
+                        cell.set_char(ch);
+                        cell.set_style(Style::default().fg(theme.accent).bg(theme.bg));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Slide-in effect: blank cells beyond the progress column.
+pub fn apply_slide_in(frame: &mut Frame, rect: Rect, progress: f64, theme: &Theme) {
+    let reveal_col = (progress * rect.width as f64) as u16;
+    let buf = frame.buffer_mut();
+
+    for y in rect.y..rect.y + rect.height {
+        for x in rect.x..rect.x + rect.width {
+            let local_x = x - rect.x;
+            if local_x > reveal_col {
+                if let Some(cell) = buf.cell_mut((x, y)) {
+                    cell.set_char(' ');
+                    cell.set_style(Style::default().bg(theme.bg));
+                }
+            }
+        }
+    }
+}
+
+/// Fade-in effect: cell-by-cell dissolve using random threshold.
+pub fn apply_fade_in(frame: &mut Frame, rect: Rect, progress: f64, theme: &Theme) {
+    let eased = progress * progress * (3.0 - 2.0 * progress); // smoothstep
+    let buf = frame.buffer_mut();
+    let mut rng = Rng::new(rect.x as u64 * 31 + rect.y as u64 * 37);
+
+    for y in rect.y..rect.y + rect.height {
+        for x in rect.x..rect.x + rect.width {
+            if rng.next_f64() > eased {
+                if let Some(cell) = buf.cell_mut((x, y)) {
+                    cell.set_char(' ');
+                    cell.set_style(Style::default().bg(theme.bg));
+                }
+            }
+        }
+    }
+}
+
+/// Compute how many code lines + char progress for typewriter effect.
+pub fn typewriter_visible(progress: f64, total_lines: usize) -> (usize, f64) {
+    if total_lines == 0 {
+        return (0, 1.0);
+    }
+    let lines_progress = progress * total_lines as f64;
+    let full_lines = (lines_progress.floor() as usize).min(total_lines);
+    let char_frac = lines_progress.fract();
+    (full_lines, char_frac)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entrance_state_progress() {
+        let state = EntranceState::new(EntranceKind::Decrypt, Duration::from_millis(400));
+        assert!(state.progress() < 0.1); // just created
+        assert!(!state.is_done());
+    }
+
+    #[test]
+    fn entrance_state_zero_duration() {
+        let state = EntranceState::new(EntranceKind::FadeIn, Duration::ZERO);
+        assert_eq!(state.progress(), 1.0);
+        assert!(state.is_done());
+    }
+
+    #[test]
+    fn tracker_starts_new_animation() {
+        let mut tracker = EntranceTracker::new();
+        tracker.on_slide_change(0);
+        let state = tracker.get_or_start(0, 0, EntranceKind::Decrypt, Duration::from_millis(600));
+        assert!(state.is_some());
+    }
+
+    #[test]
+    fn tracker_clears_on_slide_change() {
+        let mut tracker = EntranceTracker::new();
+        tracker.on_slide_change(0);
+        tracker.get_or_start(0, 0, EntranceKind::Decrypt, Duration::from_millis(600));
+        assert!(tracker.has_active());
+        tracker.on_slide_change(1);
+        assert!(!tracker.has_active());
+    }
+
+    #[test]
+    fn tracker_returns_none_when_done() {
+        let mut tracker = EntranceTracker::new();
+        tracker.on_slide_change(0);
+        // Insert a state that's already done
+        tracker.states.insert(
+            (0, 0),
+            EntranceState::new(EntranceKind::FadeIn, Duration::ZERO),
+        );
+        let state = tracker.get_or_start(0, 0, EntranceKind::FadeIn, Duration::from_millis(200));
+        assert!(state.is_none()); // already finished
+    }
+
+    #[test]
+    fn typewriter_visible_empty() {
+        let (lines, _) = typewriter_visible(0.5, 0);
+        assert_eq!(lines, 0);
+    }
+
+    #[test]
+    fn typewriter_visible_full() {
+        let (lines, frac) = typewriter_visible(1.0, 10);
+        assert_eq!(lines, 10);
+        assert!((frac - 0.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn typewriter_visible_midway() {
+        let (lines, _) = typewriter_visible(0.5, 10);
+        assert_eq!(lines, 5);
+    }
+
+    #[test]
+    fn rng_deterministic() {
+        let mut a = Rng::new(42);
+        let mut b = Rng::new(42);
+        assert_eq!(a.next(), b.next());
+    }
+}

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -1,0 +1,107 @@
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use syntect::highlighting::{FontStyle, Theme as SynTheme, ThemeSet};
+use syntect::parsing::SyntaxSet;
+
+/// Syntax highlighter backed by syntect. Maps highlighted ranges to ratatui styles.
+pub struct Highlighter {
+    syntax_set: SyntaxSet,
+    theme: SynTheme,
+}
+
+impl Highlighter {
+    pub fn new() -> Self {
+        let syntax_set = SyntaxSet::load_defaults_newlines();
+        let theme_set = ThemeSet::load_defaults();
+        let theme = theme_set.themes["base16-ocean.dark"].clone();
+        Self { syntax_set, theme }
+    }
+
+    /// Returns the syntect theme's background color for code block backgrounds.
+    pub fn bg_color(&self) -> Option<Color> {
+        self.theme
+            .settings
+            .background
+            .map(|c| Color::Rgb(c.r, c.g, c.b))
+    }
+
+    /// Highlight source code and return one `Line` per source line.
+    pub fn highlight<'a>(&self, code: &str, lang: &str) -> Vec<Line<'a>> {
+        let syntax = self
+            .syntax_set
+            .find_syntax_by_token(lang)
+            .unwrap_or_else(|| self.syntax_set.find_syntax_plain_text());
+
+        let mut h = syntect::easy::HighlightLines::new(syntax, &self.theme);
+
+        code.lines()
+            .map(|line| {
+                let ranges = h.highlight_line(line, &self.syntax_set).unwrap_or_default();
+                let spans: Vec<Span<'a>> = ranges
+                    .into_iter()
+                    .map(|(style, text)| Span::styled(text.to_string(), to_ratatui(style)))
+                    .collect();
+                Line::from(spans)
+            })
+            .collect()
+    }
+}
+
+fn to_ratatui(style: syntect::highlighting::Style) -> Style {
+    let fg = Color::Rgb(style.foreground.r, style.foreground.g, style.foreground.b);
+    let bg = Color::Rgb(style.background.r, style.background.g, style.background.b);
+    let mut s = Style::default().fg(fg).bg(bg);
+    if style.font_style.contains(FontStyle::BOLD) {
+        s = s.add_modifier(Modifier::BOLD);
+    }
+    if style.font_style.contains(FontStyle::ITALIC) {
+        s = s.add_modifier(Modifier::ITALIC);
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn highlight_rust_produces_colored_spans() {
+        let h = Highlighter::new();
+        let lines = h.highlight("fn main() {}", "rs");
+        assert_eq!(lines.len(), 1);
+        // Should have multiple styled spans (keyword, ident, punctuation)
+        assert!(
+            lines[0].spans.len() > 1,
+            "expected multiple spans, got {}",
+            lines[0].spans.len()
+        );
+    }
+
+    #[test]
+    fn highlight_unknown_lang_falls_back_to_plain() {
+        let h = Highlighter::new();
+        let lines = h.highlight("hello world", "nonexistent_language_xyz");
+        assert_eq!(lines.len(), 1);
+        assert!(!lines[0].spans.is_empty());
+    }
+
+    #[test]
+    fn highlight_multiline() {
+        let h = Highlighter::new();
+        let lines = h.highlight("line1\nline2\nline3", "txt");
+        assert_eq!(lines.len(), 3);
+    }
+
+    #[test]
+    fn highlight_empty_code() {
+        let h = Highlighter::new();
+        let lines = h.highlight("", "rs");
+        assert_eq!(lines.len(), 0);
+    }
+
+    #[test]
+    fn bg_color_returns_some() {
+        let h = Highlighter::new();
+        assert!(h.bg_color().is_some());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 mod app;
 mod background;
 mod bigtext;
+mod entrance;
+mod highlight;
 mod image_renderer;
 mod input;
 mod markdown;
@@ -106,8 +108,8 @@ fn main() -> io::Result<()> {
             terminal.backend_mut().flush()?;
         }
 
-        let timeout = if app.transition.is_some() {
-            Duration::from_millis(16) // 60fps during transitions
+        let timeout = if app.transition.is_some() || app.entrances.has_active() {
+            Duration::from_millis(16) // 60fps during transitions/entrances
         } else if app.has_active_background() || app.is_follower {
             Duration::from_millis(33) // ~30fps for backgrounds or sync polling
         } else {

--- a/src/render.rs
+++ b/src/render.rs
@@ -2,12 +2,15 @@ use std::path::Path;
 
 use ratatui::{
     layout::{Constraint, Direction, Layout as RLayout, Rect},
+    style::Style,
     text::{Line, Span as RSpan},
     widgets::{Block as WidgetBlock, Borders, Paragraph, Wrap},
     Frame,
 };
 
 use crate::bigtext;
+use crate::entrance::{self, EntranceKind, EntranceTracker};
+use crate::highlight::Highlighter;
 use crate::image_renderer::{self, DeferredImage, ImageCache, ImageProtocol};
 use crate::markdown::{Block, Span};
 use crate::parse::{Layout, Slide};
@@ -19,6 +22,9 @@ pub struct RenderCtx<'a> {
     pub image_cache: &'a mut ImageCache,
     pub deferred: &'a mut Vec<DeferredImage>,
     pub base_dir: &'a Path,
+    pub highlighter: &'a Highlighter,
+    pub entrances: &'a mut EntranceTracker,
+    pub slide_index: usize,
 }
 
 pub fn render_slide(
@@ -51,14 +57,14 @@ pub fn render_slide(
         }
         Layout::Columns => {
             let mut y = content.y;
-            for block in &slide.blocks {
+            for (i, block) in slide.blocks.iter().enumerate() {
                 let remaining = Rect::new(
                     content.x,
                     y,
                     content.width,
                     content.height.saturating_sub(y - content.y),
                 );
-                let h = render_block(frame, remaining, block, theme, ctx);
+                let (h, _) = render_block(frame, remaining, block, theme, ctx, i);
                 y += h;
             }
 
@@ -128,7 +134,7 @@ fn render_blocks(
     let mut y = area.y;
     let mut bullet_count: usize = 0;
 
-    for block in blocks {
+    for (block_idx, block) in blocks.iter().enumerate() {
         if y >= area.y + area.height {
             break;
         }
@@ -142,7 +148,7 @@ fn render_blocks(
 
         match block {
             Block::BulletList { items } => {
-                for item in items {
+                for (item_i, item) in items.iter().enumerate() {
                     if bullet_count >= reveal {
                         return;
                     }
@@ -157,33 +163,95 @@ fn render_blocks(
                     if y + h > area.y + area.height {
                         return;
                     }
+                    let bullet_rect = Rect::new(remaining.x, y, remaining.width, h);
                     frame.render_widget(
                         Paragraph::new(combined).wrap(Wrap { trim: false }),
-                        Rect::new(remaining.x, y, remaining.width, h),
+                        bullet_rect,
                     );
+
+                    // Cascade entrance for each bullet item
+                    let cascade_idx = block_idx * 100 + item_i;
+                    let stagger = std::time::Duration::from_millis(100 * item_i as u64);
+                    if let Some(state) = ctx.entrances.get_or_start(
+                        ctx.slide_index,
+                        cascade_idx,
+                        EntranceKind::Cascade,
+                        std::time::Duration::from_millis(200) + stagger,
+                    ) {
+                        let raw_progress = state.progress();
+                        // Account for stagger: animation doesn't visually start until stagger elapses
+                        let stagger_frac =
+                            stagger.as_secs_f64() / (state.duration.as_secs_f64().max(0.001));
+                        let visual_progress =
+                            ((raw_progress - stagger_frac) / (1.0 - stagger_frac)).clamp(0.0, 1.0);
+                        entrance::apply_fade_in(frame, bullet_rect, visual_progress, theme);
+                    }
+
                     y += h;
                     bullet_count += 1;
                 }
             }
             _ => {
-                let h = render_block(frame, remaining, block, theme, ctx);
+                let (h, block_rect) = render_block(frame, remaining, block, theme, ctx, block_idx);
+
+                // Apply entrance effects based on block type
+                if let Some(block_rect) = block_rect {
+                    apply_entrance_for_block(frame, block, block_rect, theme, ctx, block_idx);
+                }
+
                 y += h;
             }
         }
     }
 }
 
+fn apply_entrance_for_block(
+    frame: &mut Frame,
+    block: &Block,
+    rect: Rect,
+    theme: &Theme,
+    ctx: &mut RenderCtx,
+    block_idx: usize,
+) {
+    let (kind, duration) = match block {
+        Block::Heading { level: 1, .. } => {
+            (EntranceKind::Decrypt, std::time::Duration::from_millis(600))
+        }
+        Block::Heading { .. } => (EntranceKind::SlideIn, std::time::Duration::from_millis(300)),
+        Block::Paragraph { .. } => (EntranceKind::FadeIn, std::time::Duration::from_millis(250)),
+        Block::Image { .. } => (EntranceKind::FadeIn, std::time::Duration::from_millis(300)),
+        // Code and bullets handled separately
+        _ => return,
+    };
+
+    if let Some(state) = ctx
+        .entrances
+        .get_or_start(ctx.slide_index, block_idx, kind, duration)
+    {
+        let progress = state.progress();
+        match &state.kind {
+            EntranceKind::Decrypt => entrance::apply_decrypt(frame, rect, progress, theme),
+            EntranceKind::SlideIn => entrance::apply_slide_in(frame, rect, progress, theme),
+            EntranceKind::FadeIn => entrance::apply_fade_in(frame, rect, progress, theme),
+            _ => {}
+        }
+    }
+}
+
+/// Renders a single block and returns (consumed_height, block_rect).
 fn render_block(
     frame: &mut Frame,
     area: Rect,
     block: &Block,
     theme: &Theme,
     ctx: &mut RenderCtx,
-) -> u16 {
+    block_idx: usize,
+) -> (u16, Option<Rect>) {
     match block {
         Block::Heading { level: 1, text } => {
             let big = bigtext::render(text, theme.font);
             let height = big.len() as u16;
+            let rect = Rect::new(area.x, area.y, area.width, height.min(area.height));
             for (i, line_str) in big.iter().enumerate() {
                 if area.y + i as u16 >= area.y + area.height {
                     break;
@@ -194,24 +262,20 @@ fn render_block(
                     Rect::new(area.x, area.y + i as u16, area.width, 1),
                 );
             }
-            height + 1
+            (height + 1, Some(rect))
         }
         Block::Heading { text, .. } => {
+            let rect = Rect::new(area.x, area.y, area.width, 1);
             let line = Line::from(vec![RSpan::styled(text.clone(), theme.heading_style())]);
-            frame.render_widget(
-                Paragraph::new(line),
-                Rect::new(area.x, area.y, area.width, 1),
-            );
-            2
+            frame.render_widget(Paragraph::new(line), rect);
+            (2, Some(rect))
         }
         Block::Paragraph { spans } => {
             let line = spans_to_line(spans, theme);
             let h = estimate_line_height(&line, area.width);
-            frame.render_widget(
-                Paragraph::new(line).wrap(Wrap { trim: false }),
-                Rect::new(area.x, area.y, area.width, h),
-            );
-            h + 1
+            let rect = Rect::new(area.x, area.y, area.width, h);
+            frame.render_widget(Paragraph::new(line).wrap(Wrap { trim: false }), rect);
+            (h + 1, Some(rect))
         }
         Block::BulletList { items } => {
             let mut h = 0u16;
@@ -230,7 +294,7 @@ fn render_block(
                 );
                 h += lh;
             }
-            h
+            (h, None) // bullets handle their own entrances
         }
         Block::NumberedList { items } => {
             let mut h = 0u16;
@@ -249,24 +313,80 @@ fn render_block(
                 );
                 h += lh;
             }
-            h
+            (h, None)
         }
         Block::Code { lang, code } => {
             let title = lang.as_deref().unwrap_or("");
-            let inner_height = code.lines().count() as u16;
-            let total_height = inner_height + 2;
+            let highlighted = ctx
+                .highlighter
+                .highlight(code, if title.is_empty() { "txt" } else { title });
+            let total_lines = highlighted.len();
+            let inner_height = total_lines.max(1) as u16;
+            let total_height = inner_height + 2; // borders
+
+            // Check for typewriter entrance
+            let typewriter_dur = std::time::Duration::from_millis(50 * total_lines as u64 + 200);
+            let entrance = ctx.entrances.get_or_start(
+                ctx.slide_index,
+                block_idx,
+                EntranceKind::Typewriter,
+                typewriter_dur,
+            );
+
+            let (visible_lines, char_frac) = match entrance {
+                Some(state) => entrance::typewriter_visible(state.progress(), total_lines),
+                None => (total_lines, 1.0),
+            };
+
+            // Build visible lines with optional partial last line + cursor
+            let mut lines: Vec<Line<'static>> = Vec::with_capacity(inner_height as usize);
+            for (i, hl) in highlighted.into_iter().enumerate() {
+                if i < visible_lines {
+                    lines.push(hl);
+                } else if i == visible_lines && visible_lines < total_lines {
+                    // Partially typed current line
+                    let full_text: String = hl.spans.iter().map(|s| s.content.as_ref()).collect();
+                    let chars_to_show = (char_frac * full_text.len() as f64) as usize;
+                    if chars_to_show == 0 {
+                        // Just show cursor
+                        lines.push(Line::from(RSpan::styled("▌", theme.status_accent())));
+                    } else {
+                        // Truncate spans to chars_to_show characters
+                        let mut partial_spans: Vec<RSpan<'static>> = Vec::new();
+                        let mut chars_left = chars_to_show;
+                        for span in hl.spans {
+                            let span_len = span.content.len();
+                            if chars_left >= span_len {
+                                partial_spans.push(span);
+                                chars_left -= span_len;
+                            } else {
+                                let truncated: String =
+                                    span.content.chars().take(chars_left).collect();
+                                partial_spans.push(RSpan::styled(truncated, span.style));
+                                break;
+                            }
+                        }
+                        // Append blinking cursor
+                        partial_spans.push(RSpan::styled("▌", theme.status_accent()));
+                        lines.push(Line::from(partial_spans));
+                    }
+                } else {
+                    // Not yet visible — empty line to maintain block height
+                    lines.push(Line::from(""));
+                }
+            }
+
+            let code_bg = ctx.highlighter.bg_color().unwrap_or(theme.code_bg);
             let block_widget = WidgetBlock::default()
                 .borders(Borders::ALL)
                 .border_style(theme.code_border())
                 .title(title);
-            let paragraph = Paragraph::new(code.as_str())
-                .style(theme.code_style())
+            let paragraph = Paragraph::new(lines)
+                .style(Style::default().bg(code_bg))
                 .block(block_widget);
-            frame.render_widget(
-                paragraph,
-                Rect::new(area.x, area.y, area.width, total_height.min(area.height)),
-            );
-            total_height + 1
+            let code_rect = Rect::new(area.x, area.y, area.width, total_height.min(area.height));
+            frame.render_widget(paragraph, code_rect);
+            (total_height + 1, None) // code handles its own entrance via typewriter
         }
         Block::HorizontalRule => {
             let rule = "─".repeat(area.width as usize);
@@ -274,7 +394,7 @@ fn render_block(
                 Paragraph::new(RSpan::styled(rule, theme.rule_style())),
                 Rect::new(area.x, area.y, area.width, 1),
             );
-            2
+            (2, None)
         }
         Block::Image { path, alt } => {
             // Load, resize, and cache — only resizes once per (path, size)
@@ -295,7 +415,7 @@ fn render_block(
                             Paragraph::new(line),
                             Rect::new(area.x, area.y, area.width, 1),
                         );
-                        return 2;
+                        return (2, None);
                     }
                 };
 
@@ -336,9 +456,9 @@ fn render_block(
                 });
             }
 
-            consumed_rows + 1
+            (consumed_rows + 1, Some(img_area))
         }
-        Block::Blank => 1,
+        Block::Blank => (1, None),
     }
 }
 


### PR DESCRIPTION
## Summary

- Per-block entrance animations: headings decrypt from glitch chars, code types line-by-line with cursor, bullets cascade, paragraphs dissolve
- Syntax highlighting for code blocks via syntect (~50 languages)
- New modules: `highlight.rs`, `entrance.rs`
- Frame rate auto-elevates to 60fps during animations

Fixes #8 | Supersedes #9

## Changes

- **Cargo.toml**: Added `syntect` dependency (binary: ~1.1MB → ~2.8MB)
- **src/highlight.rs**: Syntect wrapper mapping styles to ratatui (5 tests)
- **src/entrance.rs**: `EntranceTracker` + effect implementations (9 tests)
- **src/render.rs**: Code blocks use highlighted lines + typewriter; all blocks register entrances
- **src/app.rs**: Added `Highlighter` + `EntranceTracker` to `App` and `RenderCtx`
- **src/main.rs**: 60fps during active entrances
- **examples/demo.md**: Expanded code block to showcase highlighting
- **README.md**: New sections for block entrances and syntax highlighting

**9 files changed, +737 -43** | 124 tests pass | Clippy clean

## Test plan

- [x] `cargo test` — 124 pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo build --release` — ~2.8MB binary
- [ ] Run `deck examples/demo.md` — verify heading decrypt, bullet cascade, code typewriter
- [ ] Navigate back and forward — entrances replay on slide change
- [ ] Check code block on the "Code Blocks" slide — Rust syntax should be colored