### PR TITLE
Document images, markdown reference, and author display

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ A tiny, single-binary presentation tool written in Rust. Render Markdown slides 
   - Bullet points **cascade** with staggered timing
   - Paragraphs and images **dissolve** in
 - **Big ASCII text** for `# H1` headings
+- **Images** - PNG, JPEG, GIF with auto-detection of Kitty, Sixel, or half-block rendering
 - **Progressive reveal** - bullet points appear one at a time
+- **Inline formatting** - **bold**, *italic*, `inline code`, numbered lists
 - **Column layouts** - side-by-side content with `::: columns` syntax
 - **Centered slides** - `<!-- layout: center -->` directive
 - **Speaker notes** - `<!-- note: your note -->`, visible in presenter mode
@@ -111,7 +113,7 @@ Right content here
 | Field | Values | Default |
 |-------|--------|---------|
 | `title` | Any string | `"Untitled"` |
-| `author` | Any string | - |
+| `author` | Any string (shown in status bar) | - |
 | `theme` | `"hacker"`, `"corporate"`, `"catppuccin"`, `"minimal"` | `"hacker"` |
 | `transition` | `"none"`, `"glitch"`, `"fade"`, `"wipe"`, `"dissolve"` | Theme default |
 | `background` | See backgrounds below | - |
@@ -173,6 +175,59 @@ fn main() {
 ````
 
 Combined with the typewriter entrance, code blocks type themselves out in full color — great for walking an audience through code step by step.
+
+## Images
+
+Add images with standard Markdown syntax:
+
+```markdown
+![alt text](photo.png)
+```
+
+Supported formats: **PNG**, **JPEG**, **GIF** (first frame). Images are auto-resized to fit the slide area and centered horizontally.
+
+Deck auto-detects the best rendering protocol for your terminal:
+
+| Protocol | Terminals | Quality |
+|----------|-----------|---------|
+| **Kitty** | Kitty, Ghostty, WezTerm, Konsole | Full resolution, GPU-rendered |
+| **Sixel** | iTerm2, foot | High quality ANSI fallback |
+| **Half-blocks** | Everything else | Unicode `▀` characters, works everywhere |
+
+Image paths are relative to the markdown file's directory. Absolute paths and paths that escape the presentation directory are blocked for security.
+
+## Markdown Reference
+
+Deck supports standard Markdown within slides:
+
+```markdown
+# H1 Heading          Large ASCII art
+## H2 Heading         Bold colored text
+### H3+ Heading       Bold colored text
+
+**bold text**          Bold styling
+*italic text*          Italic styling
+`inline code`          Code styling
+
+- Bullet point         Progressive reveal
+- Another point
+
+1. Numbered item       Always fully visible
+2. Another item
+
+![alt](image.png)      Inline image
+
+---                    Slide separator (between slides)
+```
+
+Code blocks use fenced syntax with a language tag for highlighting:
+
+````markdown
+```python
+def hello():
+    print("highlighted!")
+```
+````
 
 ## Keyboard Shortcuts
 


### PR DESCRIPTION
## Summary

The README was missing documentation for several core features:

- **Images** — New section: supported formats (PNG/JPEG/GIF), terminal protocol auto-detection table (Kitty/Sixel/half-blocks), path security note
- **Markdown Reference** — New section: complete syntax cheat sheet for all supported block and inline types
- **Inline formatting** — Added bold, italic, inline code, numbered lists to feature list
- **Author field** — Noted in frontmatter table that it displays in the status bar

No code changes.