### PR TITLE
Add community health files, badges, and editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,toml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/thijsvos/deck/security/policy
+    about: Report security issues privately — do not open a public issue

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## What does this change?
+
+<!-- Brief description of the change and motivation -->
+
+## How was it tested?
+
+<!-- What did you run? Manual testing, new unit tests, etc. -->
+
+- [ ] `cargo test` passes
+- [ ] `cargo clippy -- -D warnings` is clean
+- [ ] `cargo fmt --check` passes
+- [ ] Tested manually with `deck examples/demo.md`

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,21 @@
+# Security
+
+## Reporting Vulnerabilities
+
+If you discover a security issue in deck, please report it responsibly. Do not open a public GitHub issue.
+
+**Email:** Send details to the maintainer via the email address listed on the [GitHub profile](https://github.com/thijsvos).
+
+Please include:
+- A description of the vulnerability
+- Steps to reproduce it
+- The potential impact
+
+I'll acknowledge receipt within 48 hours and aim to release a fix promptly.
+
+## Scope
+
+Security-relevant areas of deck include:
+- **Image path resolution** — deck restricts image loads to the presentation's directory to prevent path traversal
+- **Sync file handling** — presenter/follower sync uses a user-private directory with atomic writes
+- **Terminal escape sequences** — deck writes raw escape sequences for Kitty/Sixel image protocols

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of Conduct
+
+## Our Standards
+
+This project is committed to providing a friendly, safe, and welcoming environment for everyone, regardless of experience level, background, or identity.
+
+Examples of behavior that contributes to a positive environment:
+
+- Being respectful and considerate in communication
+- Offering and accepting constructive feedback graciously
+- Focusing on what benefits the project and community
+- Showing empathy toward other participants
+
+Examples of unacceptable behavior:
+
+- Harassment, insults, or derogatory comments
+- Personal or political attacks
+- Publishing others' private information without consent
+- Any conduct that would reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to the project maintainer. All reports will be reviewed and addressed appropriately. The maintainer is obligated to maintain confidentiality with regard to the reporter.
+
+Project maintainers who do not follow or enforce this Code of Conduct in good faith may face temporary or permanent consequences as determined by the project leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # deck
 
+[![CI](https://github.com/thijsvos/deck/actions/workflows/ci.yml/badge.svg)](https://github.com/thijsvos/deck/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/thijsvos/deck)](https://github.com/thijsvos/deck/releases/latest)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 Terminal presentations with style.
 
 A tiny, single-binary presentation tool written in Rust. Render Markdown slides in your terminal with animated mathematical backgrounds, a hacker aesthetic, progressive bullet reveal, column layouts, and a full presenter mode.


### PR DESCRIPTION
## What does this change?

Implements GitHub best practices for a public repository:

- **SECURITY.md** — responsible disclosure policy with scope
- **PR template** — testing checklist for contributors
- **CODE_OF_CONDUCT.md** — adapted from Contributor Covenant
- **Issue template config** — disables blank issues, links to security policy
- **.editorconfig** — consistent formatting across editors
- **README badges** — CI status, latest release, license
- **Branch protection** — main now requires all 3 CI jobs to pass

## How was it tested?

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` is clean
- [x] `cargo fmt --check` passes
- [x] Branch protection verified via `gh api`