### PR TITLE
Add 42 tests covering all major untested code paths

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -786,7 +786,11 @@ mod tests {
 
     #[test]
     fn handle_key_goto_flow() {
-        let mut app = make_app(vec![dummy_slide(vec![]), dummy_slide(vec![]), dummy_slide(vec![])]);
+        let mut app = make_app(vec![
+            dummy_slide(vec![]),
+            dummy_slide(vec![]),
+            dummy_slide(vec![]),
+        ]);
         // Enter goto mode
         app.handle_key(key(KeyCode::Char(':')));
         assert!(app.in_goto);

--- a/src/app.rs
+++ b/src/app.rs
@@ -762,4 +762,113 @@ mod tests {
 
         presenter_sync.cleanup();
     }
+
+    // handle_key: action coverage
+    #[test]
+    fn handle_key_toggle_presenter() {
+        let mut app = make_app(vec![dummy_slide(vec![])]);
+        assert!(matches!(app.mode, Mode::Normal));
+        app.handle_key(key(KeyCode::Char('p')));
+        assert!(matches!(app.mode, Mode::Presenter));
+        app.handle_key(key(KeyCode::Char('p')));
+        assert!(matches!(app.mode, Mode::Normal));
+    }
+
+    #[test]
+    fn handle_key_toggle_help() {
+        let mut app = make_app(vec![dummy_slide(vec![])]);
+        assert!(!app.show_help);
+        app.handle_key(key(KeyCode::Char('?')));
+        assert!(app.show_help);
+        app.handle_key(key(KeyCode::Char('?')));
+        assert!(!app.show_help);
+    }
+
+    #[test]
+    fn handle_key_goto_flow() {
+        let mut app = make_app(vec![dummy_slide(vec![]), dummy_slide(vec![]), dummy_slide(vec![])]);
+        // Enter goto mode
+        app.handle_key(key(KeyCode::Char(':')));
+        assert!(app.in_goto);
+        assert!(app.goto_input.is_empty());
+        // Type digits
+        app.handle_key(key(KeyCode::Char('2')));
+        assert_eq!(app.goto_input, "2");
+        // Confirm
+        app.handle_key(key(KeyCode::Enter));
+        assert!(!app.in_goto);
+        assert_eq!(app.slide_index, 1); // slide 2 = index 1
+    }
+
+    #[test]
+    fn handle_key_goto_confirm_invalid() {
+        let mut app = make_app(vec![dummy_slide(vec![]), dummy_slide(vec![])]);
+        app.in_goto = true;
+        app.goto_input = "abc".into();
+        app.handle_key(key(KeyCode::Enter));
+        assert!(!app.in_goto);
+        assert_eq!(app.slide_index, 0); // stays put
+    }
+
+    #[test]
+    fn handle_key_goto_cancel() {
+        let mut app = make_app(vec![dummy_slide(vec![])]);
+        app.in_goto = true;
+        app.goto_input = "5".into();
+        app.handle_key(key(KeyCode::Esc));
+        assert!(!app.in_goto);
+        assert!(app.goto_input.is_empty());
+    }
+
+    #[test]
+    fn handle_key_esc_closes_goto_first() {
+        let mut app = make_app(vec![dummy_slide(vec![])]);
+        app.in_goto = true;
+        assert!(!app.handle_key(key(KeyCode::Esc))); // Esc in goto = cancel, not quit
+        assert!(!app.in_goto);
+    }
+
+    #[test]
+    fn handle_key_reset_timer() {
+        let mut app = make_app(vec![dummy_slide(vec![])]);
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let before = app.timer;
+        app.handle_key(key(KeyCode::Char('r')));
+        assert!(app.timer > before);
+    }
+
+    // State logic
+    #[test]
+    fn has_active_background_true() {
+        let mut slide = dummy_slide(vec![]);
+        slide.background = Some(crate::background::BackgroundKind::Matrix);
+        let app = make_app(vec![slide]);
+        assert!(app.has_active_background());
+    }
+
+    #[test]
+    fn has_active_background_false() {
+        let app = make_app(vec![dummy_slide(vec![])]);
+        assert!(!app.has_active_background());
+    }
+
+    #[test]
+    fn start_transition_uses_theme_default() {
+        let mut app = make_app(vec![dummy_slide(vec![]), dummy_slide(vec![])]);
+        // Default deck meta has TransitionKind::None, so theme default (Glitch) is used
+        app.go_to(1);
+        assert!(app.transition.is_some());
+    }
+
+    #[test]
+    fn tick_clears_finished_transition() {
+        let mut app = make_app(vec![dummy_slide(vec![])]);
+        app.transition = Some(crate::transition::TransitionState::new(
+            crate::transition::TransitionKind::Fade,
+        ));
+        // Set duration to zero so it's immediately done
+        app.transition.as_mut().unwrap().duration = std::time::Duration::ZERO;
+        app.tick();
+        assert!(app.transition.is_none());
+    }
 }

--- a/src/background.rs
+++ b/src/background.rs
@@ -747,4 +747,30 @@ mod tests {
         assert_eq!(ch, ' ');
         assert_eq!(b, 0.0);
     }
+
+    #[test]
+    fn from_str_all_valid_names() {
+        let names = [
+            "matrix", "plasma", "lissajous", "spiral", "wave", "aurora", "rain", "noise",
+            "lattice", "orbit",
+        ];
+        for name in names {
+            assert!(
+                name.parse::<BackgroundKind>().is_ok(),
+                "failed to parse '{name}'"
+            );
+        }
+    }
+
+    #[test]
+    fn from_str_unknown_returns_err() {
+        assert!("fire".parse::<BackgroundKind>().is_err());
+        assert!("".parse::<BackgroundKind>().is_err());
+    }
+
+    #[test]
+    fn from_str_case_sensitive() {
+        assert!("Matrix".parse::<BackgroundKind>().is_err());
+        assert!("AURORA".parse::<BackgroundKind>().is_err());
+    }
 }

--- a/src/background.rs
+++ b/src/background.rs
@@ -751,8 +751,16 @@ mod tests {
     #[test]
     fn from_str_all_valid_names() {
         let names = [
-            "matrix", "plasma", "lissajous", "spiral", "wave", "aurora", "rain", "noise",
-            "lattice", "orbit",
+            "matrix",
+            "plasma",
+            "lissajous",
+            "spiral",
+            "wave",
+            "aurora",
+            "rain",
+            "noise",
+            "lattice",
+            "orbit",
         ];
         for name in names {
             assert!(

--- a/src/bigtext.rs
+++ b/src/bigtext.rs
@@ -488,4 +488,25 @@ mod tests {
         // Each line should contain a space separator between H and I glyphs
         assert!(lines[0].contains(' '));
     }
+
+    #[test]
+    fn glyph_block_all_digits() {
+        for d in '0'..='9' {
+            assert!(glyph_block(d).is_some(), "glyph_block missing digit '{d}'");
+        }
+    }
+
+    #[test]
+    fn glyph_large_all_digits() {
+        for d in '0'..='9' {
+            assert!(glyph_large(d).is_some(), "glyph_large missing digit '{d}'");
+        }
+    }
+
+    #[test]
+    fn unsupported_char_returns_none() {
+        assert!(glyph_block('~').is_none());
+        assert!(glyph_block('(').is_none());
+        assert!(glyph_large('~').is_none());
+    }
 }

--- a/src/entrance.rs
+++ b/src/entrance.rs
@@ -270,4 +270,25 @@ mod tests {
         let mut b = Rng::new(42);
         assert_eq!(a.next(), b.next());
     }
+
+    #[test]
+    fn typewriter_visible_zero_progress() {
+        let (lines, frac) = typewriter_visible(0.0, 10);
+        assert_eq!(lines, 0);
+        assert!((frac - 0.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn typewriter_visible_over_one_clamps() {
+        let (lines, _) = typewriter_visible(1.5, 10);
+        assert_eq!(lines, 10); // min(15, 10) = 10
+    }
+
+    #[test]
+    fn tracker_has_active_with_running() {
+        let mut tracker = EntranceTracker::new();
+        tracker.on_slide_change(0);
+        tracker.get_or_start(0, 0, EntranceKind::Decrypt, Duration::from_secs(10));
+        assert!(tracker.has_active());
+    }
 }

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -104,4 +104,25 @@ mod tests {
         let h = Highlighter::new();
         assert!(h.bg_color().is_some());
     }
+
+    #[test]
+    fn highlight_rust_keywords_have_color() {
+        let h = Highlighter::new();
+        let lines = h.highlight("fn main() {}", "rs");
+        // "fn" keyword should have a non-default foreground color
+        let first_span = &lines[0].spans[0];
+        assert!(
+            matches!(first_span.style.fg, Some(Color::Rgb(_, _, _))),
+            "expected RGB color on keyword"
+        );
+    }
+
+    #[test]
+    fn highlight_comment_produces_styled_span() {
+        let h = Highlighter::new();
+        let lines = h.highlight("// a comment", "rs");
+        assert!(!lines[0].spans.is_empty());
+        // Comment should have some foreground color
+        assert!(lines[0].spans[0].style.fg.is_some());
+    }
 }

--- a/src/image_renderer.rs
+++ b/src/image_renderer.rs
@@ -423,4 +423,47 @@ mod tests {
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '='));
     }
+
+    #[test]
+    fn resize_1x1_upscales_with_even_height() {
+        let img = make_image(1, 1);
+        let resized = resize_to_fit(&img, 100, 50);
+        assert!(resized.width() > 1);
+        assert!(resized.height() > 1);
+        assert!(resized.height().is_multiple_of(2));
+    }
+
+    #[test]
+    fn render_halfblocks_small_image() {
+        use ratatui::buffer::Buffer;
+        let mut img = RgbaImage::new(2, 2);
+        img.put_pixel(0, 0, image::Rgba([255, 0, 0, 255])); // top-left red
+        img.put_pixel(1, 0, image::Rgba([0, 255, 0, 255])); // top-right green
+        img.put_pixel(0, 1, image::Rgba([0, 0, 255, 255])); // bot-left blue
+        img.put_pixel(1, 1, image::Rgba([255, 255, 0, 255])); // bot-right yellow
+
+        let area = Rect::new(0, 0, 2, 1); // 2 cols x 1 row = 2x2 pixels
+        let mut buf = Buffer::empty(area);
+        render_halfblocks(&mut buf, area, &img);
+
+        // Both cells should be '▀'
+        assert_eq!(buf.cell((0, 0)).unwrap().symbol(), "▀");
+        assert_eq!(buf.cell((1, 0)).unwrap().symbol(), "▀");
+    }
+
+    #[test]
+    fn flush_deferred_halfblocks_is_noop() {
+        let images = vec![DeferredImage {
+            x: 0,
+            y: 0,
+            cols: 2,
+            rows: 1,
+            rgba: std::sync::Arc::new(make_image(2, 2)),
+            protocol: ImageProtocol::HalfBlocks,
+            kitty_b64: None,
+        }];
+        let mut output = Vec::new();
+        flush_deferred(&mut output, &images).unwrap();
+        assert!(output.is_empty()); // HalfBlocks writes nothing
+    }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -147,10 +147,7 @@ mod tests {
     #[test]
     fn down_and_enter_map_to_next() {
         assert!(matches!(map_key(key(KeyCode::Down), false), Action::Next));
-        assert!(matches!(
-            map_key(key(KeyCode::Enter), false),
-            Action::Next
-        ));
+        assert!(matches!(map_key(key(KeyCode::Enter), false), Action::Next));
     }
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -143,4 +143,30 @@ mod tests {
             Action::Last
         ));
     }
+
+    #[test]
+    fn down_and_enter_map_to_next() {
+        assert!(matches!(map_key(key(KeyCode::Down), false), Action::Next));
+        assert!(matches!(
+            map_key(key(KeyCode::Enter), false),
+            Action::Next
+        ));
+    }
+
+    #[test]
+    fn up_and_backspace_map_to_prev() {
+        assert!(matches!(map_key(key(KeyCode::Up), false), Action::Prev));
+        assert!(matches!(
+            map_key(key(KeyCode::Backspace), false),
+            Action::Prev
+        ));
+    }
+
+    #[test]
+    fn goto_backspace_in_goto_mode() {
+        assert!(matches!(
+            map_key(key(KeyCode::Backspace), true),
+            Action::GoToBackspace
+        ));
+    }
 }

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -297,4 +297,34 @@ mod tests {
             panic!("expected image, got {:?}", blocks[0]);
         }
     }
+
+    #[test]
+    fn parse_empty_input() {
+        let blocks = parse_blocks("");
+        assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn parse_code_block_no_language() {
+        let blocks = parse_blocks("```\nplain code\n```");
+        if let Block::Code { lang, code } = &blocks[0] {
+            assert!(lang.is_none());
+            assert!(code.contains("plain code"));
+        } else {
+            panic!("expected code block");
+        }
+    }
+
+    #[test]
+    fn parse_h3_through_h6() {
+        for level in 3..=6u8 {
+            let hashes = "#".repeat(level as usize);
+            let input = format!("{hashes} Level {level}");
+            let blocks = parse_blocks(&input);
+            assert!(
+                matches!(&blocks[0], Block::Heading { level: l, .. } if *l == level),
+                "H{level} not parsed correctly"
+            );
+        }
+    }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -350,4 +350,31 @@ mod tests {
         assert!(deck.slides[0].background.is_some());
         assert!(deck.slides[1].background.is_none());
     }
+
+    #[test]
+    fn empty_input_produces_no_slides() {
+        let deck = parse_deck("");
+        assert!(deck.slides.is_empty());
+    }
+
+    #[test]
+    fn malformed_frontmatter_falls_back_to_defaults() {
+        let input = "---\nbad = [\n---\n# Slide";
+        let deck = parse_deck(input);
+        assert_eq!(deck.meta.title, "Untitled");
+    }
+
+    #[test]
+    fn multiple_notes_extracted() {
+        let input = "# Slide\n<!-- note: First -->\n<!-- note: Second -->";
+        let deck = parse_deck(input);
+        assert_eq!(deck.slides[0].notes, vec!["First", "Second"]);
+    }
+
+    #[test]
+    fn unknown_background_name_ignored() {
+        let input = "<!-- background: fire -->\n# Title";
+        let deck = parse_deck(input);
+        assert!(deck.slides[0].background.is_none());
+    }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -605,4 +605,48 @@ mod tests {
         let line = spans_to_line(&spans, &theme);
         assert_eq!(line.spans.len(), 2);
     }
+
+    #[test]
+    fn estimate_height_bullet_list() {
+        let blocks = vec![Block::BulletList {
+            items: vec![
+                crate::markdown::ListItem {
+                    spans: vec![Span::Plain("a".into())],
+                },
+                crate::markdown::ListItem {
+                    spans: vec![Span::Plain("b".into())],
+                },
+                crate::markdown::ListItem {
+                    spans: vec![Span::Plain("c".into())],
+                },
+            ],
+        }];
+        assert_eq!(estimate_height(&blocks, 80), 3);
+    }
+
+    #[test]
+    fn estimate_height_code_block() {
+        let blocks = vec![Block::Code {
+            lang: Some("rust".into()),
+            code: "fn a() {}\nfn b() {}\nfn c() {}".into(),
+        }];
+        // 3 lines + 3 (borders + spacing) = 6
+        assert_eq!(estimate_height(&blocks, 80), 6);
+    }
+
+    #[test]
+    fn estimate_height_mixed_blocks() {
+        let blocks = vec![
+            Block::Heading {
+                level: 1,
+                text: "Title".into(),
+            },
+            Block::Paragraph {
+                spans: vec![Span::Plain("hello".into())],
+            },
+            Block::HorizontalRule,
+        ];
+        // H1=8, paragraph=2 (ceil(5/80)+1), rule=2 = 12
+        assert_eq!(estimate_height(&blocks, 80), 12);
+    }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -215,4 +215,32 @@ mod tests {
         assert_eq!(style.fg, Some(t.fg));
         assert_eq!(style.bg, Some(t.bg));
     }
+
+    #[test]
+    fn bold_style_has_bold_modifier() {
+        let t = Theme::from_name(&ThemeName::Hacker);
+        assert!(t.bold_style().add_modifier.contains(Modifier::BOLD));
+        assert_eq!(t.bold_style().fg, Some(t.bold));
+    }
+
+    #[test]
+    fn italic_style_has_italic_modifier() {
+        let t = Theme::from_name(&ThemeName::Hacker);
+        assert!(t.italic_style().add_modifier.contains(Modifier::ITALIC));
+        assert_eq!(t.italic_style().fg, Some(t.italic));
+    }
+
+    #[test]
+    fn code_style_uses_code_colors() {
+        let t = Theme::from_name(&ThemeName::Hacker);
+        assert_eq!(t.code_style().fg, Some(t.code_fg));
+        assert_eq!(t.code_style().bg, Some(t.code_bg));
+    }
+
+    #[test]
+    fn status_accent_uses_accent() {
+        let t = Theme::from_name(&ThemeName::Hacker);
+        assert_eq!(t.status_accent().fg, Some(t.accent));
+        assert_eq!(t.status_accent().bg, Some(t.bg));
+    }
 }


### PR DESCRIPTION
## What does this change?

Adds 42 new tests across 10 modules, bringing total coverage from 124 to 166 tests. Covers all previously untested pure functions and state logic.

Key areas now covered:
- All `handle_key` action variants (toggle presenter, help, goto flow, cancel, timer reset)
- `BackgroundKind::from_str` (all 10 variants + error cases)
- All theme style methods (bold, italic, code, status_accent)
- Glyph completeness for digits, entrance edge cases, image halfblock rendering
- Parse edge cases (empty input, malformed frontmatter, multiple notes, unknown backgrounds)
- Markdown edge cases (empty input, code block without lang, H3-H6)

## How was it tested?

- [x] `cargo test` passes (166 tests)
- [x] `cargo clippy -- -D warnings` is clean
- [x] `cargo fmt --check` passes