### PR TITLE
Fix Unicode width bugs, cache highlighting, deduplicate Rng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "serde",
  "syntect",
  "toml",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1", features = ["derive"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif"] }
 base64 = "0.22"
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }
+unicode-width = "0.2"
 
 [profile.release]
 strip = true

--- a/README.md
+++ b/README.md
@@ -254,9 +254,9 @@ Use `--theme corporate` or set `theme = "corporate"` in frontmatter.
 | Theme | Look | Font | Transition |
 |-------|------|------|------------|
 | **hacker** (default) | Matrix green, neon pink, cyan headings | Block (`█`) | Glitch |
-| **corporate** | Navy, blue headings, gold accents | Thin (`┌─┐`) | Wipe |
+| **corporate** | Navy, blue headings, gold accents | Large (`██`) | Wipe |
 | **catppuccin** | Mocha palette, pink accents, peach bold | Block (`█`) | Dissolve |
-| **minimal** | Terminal defaults, white, yellow accents | Thin (`┌─┐`) | Fade |
+| **minimal** | Terminal defaults, white, yellow accents | Large (`██`) | Fade |
 
 Each theme carries its own default transition and font style. Override with `transition = "glitch"` in frontmatter.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -115,7 +115,7 @@ impl App {
             image_cache: &mut self.image_cache,
             deferred: &mut self.deferred_images,
             base_dir: &self.base_dir,
-            highlighter: &self.highlighter,
+            highlighter: &mut self.highlighter,
             entrances: &mut self.entrances,
             slide_index: self.slide_index,
         };

--- a/src/entrance.rs
+++ b/src/entrance.rs
@@ -99,31 +99,7 @@ impl EntranceTracker {
     }
 }
 
-// ── Glitch character set (shared with transition.rs) ─────────────
-
-const GLITCH_CHARS: &[char] = &[
-    '!', '@', '#', '$', '%', '^', '&', '*', '<', '>', '{', '}', '[', ']', '|', '/', '\\', '~', '░',
-    '▒', '▓', '█', '▄', '▀', '▌', '▐',
-];
-
-// ── Simple RNG (same xorshift as transition.rs) ──────────────────
-
-struct Rng(u64);
-
-impl Rng {
-    fn new(seed: u64) -> Self {
-        Self(seed | 1)
-    }
-    fn next(&mut self) -> u64 {
-        self.0 ^= self.0 << 13;
-        self.0 ^= self.0 >> 7;
-        self.0 ^= self.0 << 17;
-        self.0
-    }
-    fn next_f64(&mut self) -> f64 {
-        (self.next() % 10000) as f64 / 10000.0
-    }
-}
+use crate::util::{Rng, GLITCH_CHARS};
 
 // ── Entrance effect implementations ──────────────────────────────
 

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -1,12 +1,15 @@
+use std::collections::HashMap;
+
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use syntect::highlighting::{FontStyle, Theme as SynTheme, ThemeSet};
 use syntect::parsing::SyntaxSet;
 
-/// Syntax highlighter backed by syntect. Maps highlighted ranges to ratatui styles.
+/// Syntax highlighter backed by syntect. Caches results per (code, lang) pair.
 pub struct Highlighter {
     syntax_set: SyntaxSet,
     theme: SynTheme,
+    cache: HashMap<(u64, String), Vec<Line<'static>>>,
 }
 
 impl Highlighter {
@@ -14,7 +17,11 @@ impl Highlighter {
         let syntax_set = SyntaxSet::load_defaults_newlines();
         let theme_set = ThemeSet::load_defaults();
         let theme = theme_set.themes["base16-ocean.dark"].clone();
-        Self { syntax_set, theme }
+        Self {
+            syntax_set,
+            theme,
+            cache: HashMap::new(),
+        }
     }
 
     /// Returns the syntect theme's background color for code block backgrounds.
@@ -26,7 +33,13 @@ impl Highlighter {
     }
 
     /// Highlight source code and return one `Line` per source line.
-    pub fn highlight<'a>(&self, code: &str, lang: &str) -> Vec<Line<'a>> {
+    /// Results are cached per (code, lang) so repeated calls are free.
+    pub fn highlight(&mut self, code: &str, lang: &str) -> Vec<Line<'static>> {
+        let key = (hash_str(code), lang.to_string());
+        if let Some(cached) = self.cache.get(&key) {
+            return cached.clone();
+        }
+
         let syntax = self
             .syntax_set
             .find_syntax_by_token(lang)
@@ -34,17 +47,31 @@ impl Highlighter {
 
         let mut h = syntect::easy::HighlightLines::new(syntax, &self.theme);
 
-        code.lines()
+        let lines: Vec<Line<'static>> = code
+            .lines()
             .map(|line| {
                 let ranges = h.highlight_line(line, &self.syntax_set).unwrap_or_default();
-                let spans: Vec<Span<'a>> = ranges
+                let spans: Vec<Span<'static>> = ranges
                     .into_iter()
                     .map(|(style, text)| Span::styled(text.to_string(), to_ratatui(style)))
                     .collect();
                 Line::from(spans)
             })
-            .collect()
+            .collect();
+
+        self.cache.insert(key.clone(), lines.clone());
+        lines
     }
+}
+
+/// Simple FNV-1a hash for cache keys.
+fn hash_str(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in s.bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
 }
 
 fn to_ratatui(style: syntect::highlighting::Style) -> Style {
@@ -66,10 +93,9 @@ mod tests {
 
     #[test]
     fn highlight_rust_produces_colored_spans() {
-        let h = Highlighter::new();
+        let mut h = Highlighter::new();
         let lines = h.highlight("fn main() {}", "rs");
         assert_eq!(lines.len(), 1);
-        // Should have multiple styled spans (keyword, ident, punctuation)
         assert!(
             lines[0].spans.len() > 1,
             "expected multiple spans, got {}",
@@ -79,7 +105,7 @@ mod tests {
 
     #[test]
     fn highlight_unknown_lang_falls_back_to_plain() {
-        let h = Highlighter::new();
+        let mut h = Highlighter::new();
         let lines = h.highlight("hello world", "nonexistent_language_xyz");
         assert_eq!(lines.len(), 1);
         assert!(!lines[0].spans.is_empty());
@@ -87,14 +113,14 @@ mod tests {
 
     #[test]
     fn highlight_multiline() {
-        let h = Highlighter::new();
+        let mut h = Highlighter::new();
         let lines = h.highlight("line1\nline2\nline3", "txt");
         assert_eq!(lines.len(), 3);
     }
 
     #[test]
     fn highlight_empty_code() {
-        let h = Highlighter::new();
+        let mut h = Highlighter::new();
         let lines = h.highlight("", "rs");
         assert_eq!(lines.len(), 0);
     }
@@ -107,9 +133,8 @@ mod tests {
 
     #[test]
     fn highlight_rust_keywords_have_color() {
-        let h = Highlighter::new();
+        let mut h = Highlighter::new();
         let lines = h.highlight("fn main() {}", "rs");
-        // "fn" keyword should have a non-default foreground color
         let first_span = &lines[0].spans[0];
         assert!(
             matches!(first_span.style.fg, Some(Color::Rgb(_, _, _))),
@@ -119,10 +144,18 @@ mod tests {
 
     #[test]
     fn highlight_comment_produces_styled_span() {
-        let h = Highlighter::new();
+        let mut h = Highlighter::new();
         let lines = h.highlight("// a comment", "rs");
         assert!(!lines[0].spans.is_empty());
-        // Comment should have some foreground color
         assert!(lines[0].spans[0].style.fg.is_some());
+    }
+
+    #[test]
+    fn highlight_caches_results() {
+        let mut h = Highlighter::new();
+        let lines1 = h.highlight("fn foo() {}", "rs");
+        let lines2 = h.highlight("fn foo() {}", "rs");
+        assert_eq!(lines1.len(), lines2.len());
+        assert_eq!(h.cache.len(), 1);
     }
 }

--- a/src/image_renderer.rs
+++ b/src/image_renderer.rs
@@ -31,13 +31,15 @@ pub struct ImageCache {
     max_resized: usize,
 }
 
+const DEFAULT_MAX_RESIZED: usize = 64;
+
 impl ImageCache {
     pub fn new() -> Self {
         Self {
             originals: HashMap::new(),
             resized: HashMap::new(),
             encoded: HashMap::new(),
-            max_resized: 64,
+            max_resized: DEFAULT_MAX_RESIZED,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod render_presenter;
 mod sync;
 mod theme;
 mod transition;
+mod util;
 
 use std::io::{self, Write};
 use std::path::Path;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -208,7 +208,6 @@ fn extract_columns(raw: &str) -> Option<(String, String, String)> {
     let mut right = String::new();
     let mut in_left = false;
     let mut in_right = false;
-    let mut depth = 0;
 
     for line in &lines[col_start + 1..] {
         let trimmed = line.trim();
@@ -232,10 +231,7 @@ fn extract_columns(raw: &str) -> Option<(String, String, String)> {
                 in_right = false;
                 continue;
             }
-            if depth == 0 {
-                break;
-            }
-            depth -= 1;
+            break;
         }
 
         if in_left {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use unicode_width::UnicodeWidthStr;
+
 use ratatui::{
     layout::{Constraint, Direction, Layout as RLayout, Rect},
     style::Style,
@@ -22,7 +24,7 @@ pub struct RenderCtx<'a> {
     pub image_cache: &'a mut ImageCache,
     pub deferred: &'a mut Vec<DeferredImage>,
     pub base_dir: &'a Path,
-    pub highlighter: &'a Highlighter,
+    pub highlighter: &'a mut Highlighter,
     pub entrances: &'a mut EntranceTracker,
     pub slide_index: usize,
 }
@@ -110,7 +112,7 @@ pub fn render_status_bar(
     let right = format!(" {mins:02}:{secs:02} ");
 
     let width = area.width as usize;
-    let used = left.len() + center.len() + right.len();
+    let used = left.width() + center.width() + right.width();
     let pad = width.saturating_sub(used);
     let left_pad = pad / 2;
     let right_pad = pad.saturating_sub(left_pad);
@@ -174,17 +176,17 @@ fn render_blocks(
                         bullet_rect,
                     );
 
-                    // Cascade entrance for each bullet item
+                    // Cascade entrance: fixed 300ms animation per bullet, staggered start
                     let cascade_idx = block_idx * 100 + item_i;
-                    let stagger = std::time::Duration::from_millis(100 * item_i as u64);
+                    let stagger = std::time::Duration::from_millis(80 * item_i as u64);
+                    let anim_dur = std::time::Duration::from_millis(300);
                     if let Some(state) = ctx.entrances.get_or_start(
                         ctx.slide_index,
                         cascade_idx,
                         EntranceKind::Cascade,
-                        std::time::Duration::from_millis(200) + stagger,
+                        stagger + anim_dur,
                     ) {
                         let raw_progress = state.progress();
-                        // Account for stagger: animation doesn't visually start until stagger elapses
                         let stagger_frac =
                             stagger.as_secs_f64() / (state.duration.as_secs_f64().max(0.001));
                         let visual_progress =
@@ -351,7 +353,7 @@ fn render_block(
                 } else if i == visible_lines && visible_lines < total_lines {
                     // Partially typed current line
                     let full_text: String = hl.spans.iter().map(|s| s.content.as_ref()).collect();
-                    let chars_to_show = (char_frac * full_text.len() as f64) as usize;
+                    let chars_to_show = (char_frac * full_text.chars().count() as f64) as usize;
                     if chars_to_show == 0 {
                         // Just show cursor
                         lines.push(Line::from(RSpan::styled("▌", theme.status_accent())));
@@ -360,7 +362,7 @@ fn render_block(
                         let mut partial_spans: Vec<RSpan<'static>> = Vec::new();
                         let mut chars_left = chars_to_show;
                         for span in hl.spans {
-                            let span_len = span.content.len();
+                            let span_len = span.content.chars().count();
                             if chars_left >= span_len {
                                 partial_spans.push(span);
                                 chars_left -= span_len;
@@ -483,7 +485,7 @@ fn estimate_line_height(line: &Line, width: u16) -> u16 {
     if width == 0 {
         return 1;
     }
-    let text_width: usize = line.spans.iter().map(|s| s.content.len()).sum();
+    let text_width: usize = line.spans.iter().map(|s| s.content.width()).sum();
     let w = width as usize;
     text_width.div_ceil(w).max(1).min(u16::MAX as usize) as u16
 }
@@ -492,13 +494,15 @@ fn estimate_height(blocks: &[Block], width: u16) -> u16 {
     blocks
         .iter()
         .map(|b| match b {
-            Block::Heading { level: 1, .. } => 8, // 5-7 row font + spacing
+            Block::Heading { level: 1, .. } => 8, // max(Block=6, Large=8) for centering
             Block::Heading { .. } => 2,
             Block::Paragraph { spans } => {
                 let text_len: usize = spans
                     .iter()
                     .map(|s| match s {
-                        Span::Plain(t) | Span::Bold(t) | Span::Italic(t) | Span::Code(t) => t.len(),
+                        Span::Plain(t) | Span::Bold(t) | Span::Italic(t) | Span::Code(t) => {
+                            t.width()
+                        }
                     })
                     .sum();
                 let w = width.max(1) as usize;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -109,9 +109,7 @@ impl Theme {
     }
 
     pub fn h1_style(&self) -> Style {
-        Style::default()
-            .fg(self.heading)
-            .add_modifier(Modifier::BOLD)
+        self.heading_style()
     }
 
     pub fn heading_style(&self) -> Style {

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -36,29 +36,7 @@ impl TransitionState {
     }
 }
 
-struct Rng(u64);
-
-impl Rng {
-    fn new(seed: u64) -> Self {
-        Self(seed | 1)
-    }
-
-    fn next(&mut self) -> u64 {
-        self.0 ^= self.0 << 13;
-        self.0 ^= self.0 >> 7;
-        self.0 ^= self.0 << 17;
-        self.0
-    }
-
-    fn next_f64(&mut self) -> f64 {
-        (self.next() % 10000) as f64 / 10000.0
-    }
-}
-
-const GLITCH_CHARS: &[char] = &[
-    '!', '@', '#', '$', '%', '^', '&', '*', '<', '>', '{', '}', '[', ']', '|', '/', '\\', '~', '░',
-    '▒', '▓', '█', '▄', '▀', '▌', '▐',
-];
+use crate::util::{Rng, GLITCH_CHARS};
 
 /// Apply transition overlay on top of already-rendered slide content.
 pub fn apply_transition(frame: &mut Frame, area: Rect, state: &TransitionState, theme: &Theme) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,24 @@
+/// Shared xorshift64 RNG used by transitions and entrance animations.
+pub struct Rng(u64);
+
+impl Rng {
+    pub fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+
+    pub fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+
+    pub fn next_f64(&mut self) -> f64 {
+        (self.next() % 10000) as f64 / 10000.0
+    }
+}
+
+pub const GLITCH_CHARS: &[char] = &[
+    '!', '@', '#', '$', '%', '^', '&', '*', '<', '>', '{', '}', '[', ']', '|', '/', '\\', '~', '░',
+    '▒', '▓', '█', '▄', '▀', '▌', '▐',
+];


### PR DESCRIPTION
## What does this change?

Fixes all findings from code review v2.

**Critical (2):**
- `estimate_line_height` and status bar now use `unicode-width` for display-width measurement instead of byte `.len()`
- Typewriter truncation uses `chars().count()` consistently

**Warnings (6):**
- Syntax highlighting cached per `(code, lang)` — no more regex parsing every frame
- Bullet cascade uses fixed 300ms animation per item (was degrading for long lists)
- Dead `depth` variable removed from `extract_columns`
- README fixed: corporate/minimal themes use "Large" font, not "Thin"
- Shared `Rng` and `GLITCH_CHARS` extracted to `src/util.rs`
- H1 height estimate documented

**Suggestions (3):**
- `h1_style()` delegates to `heading_style()`
- Named constant `DEFAULT_MAX_RESIZED` for image cache
- `FmtWrite` import confirmed necessary (kept)

## How was it tested?

- [x] `cargo test` — 167 pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean