### PR TITLE
Fix sync canonicalization, image bombs, hot-path performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Security
+- Cap decoded image dimensions and allocations to defuse decompression-bomb images
+  in shared decks
+
+### Fixed
+- Sync files now connect across CWDs and absolute/relative path forms by
+  canonicalizing the input path before hashing
+- Image references with absolute paths (e.g. `/usr/share/icons/foo.png`) are no
+  longer silently rejected by the path-traversal sandbox
+- Frontmatter parser handles CRLF line endings (Windows-authored markdown)
+- Decrypt entrance no longer corrupts wide-grapheme continuation cells in titles
+- Big-text rendering falls back to plain text when any character lacks a glyph,
+  rather than silently dropping the unsupported chars (e.g. "café" → "CAFÉ")
+
+### Performance
+- Highlighted code blocks cached behind `Arc` — cache hits are a refcount bump
+  instead of a deep clone of every line and span
+- Image cache keyed by the raw `src` string so repeated frames skip
+  per-frame `canonicalize` syscalls
+- Image cache uses FIFO eviction (one entry at a time) instead of clearing
+  the whole cache on overflow; originals are now bounded too
+
+### Internal
+- Shared FNV-1a `fnv1a` helper in `util.rs`, replacing duplicated impls
+- `Rng::next_f64` now uses the full 53-bit f64 mantissa (no modulo bias)
+- Sync and app tests use unique per-test paths so parallel `cargo test` runs
+  do not collide
+- Defensive `saturating_sub(1)` on `slides.len()` at navigation call sites
+- Exhaustive `EntranceKind` match in render — adding a new variant is a
+  compile error, not a silent no-op
+
 ## [0.1.0] - 2026-04-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Terminal presentations with style.
 
 A tiny, single-binary presentation tool written in Rust. Render Markdown slides in your terminal with animated mathematical backgrounds, a hacker aesthetic, progressive bullet reveal, column layouts, and a full presenter mode.
 
-**~3 MB binary. No server. No dependencies. Just `deck talk.md`.**
+**~3 MB binary. No server. No runtime dependencies. Just `deck talk.md`.**
 
 ## Features
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -204,7 +204,7 @@ impl App {
             Action::Next => self.advance(),
             Action::Prev => self.go_back(),
             Action::First => self.go_to(0),
-            Action::Last => self.go_to(self.deck.slides.len() - 1),
+            Action::Last => self.go_to(self.deck.slides.len().saturating_sub(1)),
             Action::TogglePresenter => {
                 self.mode = match self.mode {
                     Mode::Normal => Mode::Presenter,
@@ -224,7 +224,9 @@ impl App {
             }
             Action::GoToConfirm => {
                 if let Ok(n) = self.goto_input.parse::<usize>() {
-                    let target = n.saturating_sub(1).min(self.deck.slides.len() - 1);
+                    let target = n
+                        .saturating_sub(1)
+                        .min(self.deck.slides.len().saturating_sub(1));
                     self.go_to(target);
                 }
                 self.in_goto = false;
@@ -279,7 +281,7 @@ impl App {
         let total_bullets = count_bullets(&self.deck.slides[self.slide_index]);
         if total_bullets > 0 && self.reveal_count < total_bullets {
             self.reveal_count += 1;
-        } else if self.slide_index < self.deck.slides.len() - 1 {
+        } else if self.slide_index + 1 < self.deck.slides.len() {
             self.slide_index += 1;
             self.reveal_count = initial_reveal(&self.deck.slides[self.slide_index]);
             self.start_transition();
@@ -305,7 +307,7 @@ impl App {
     }
 
     fn go_to(&mut self, index: usize) {
-        let new_index = index.min(self.deck.slides.len() - 1);
+        let new_index = index.min(self.deck.slides.len().saturating_sub(1));
         if new_index != self.slide_index {
             self.slide_index = new_index;
             self.reveal_count = initial_reveal(&self.deck.slides[self.slide_index]);
@@ -620,11 +622,25 @@ mod tests {
         assert_eq!(app.slide_index, 0); // didn't move
     }
 
+    /// Per-test sync key so parallel `cargo test` runs do not collide.
+    fn unique_sync_key(label: &str) -> String {
+        format!(
+            "/__deck_test_sync__{}__{}__{}",
+            label,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        )
+    }
+
     #[test]
     fn presenter_writes_sync_follower_reads() {
         use crate::sync::SyncFile;
 
-        let sync_path = "/__deck_test_sync_presenter_follower__";
+        let sync_path_owned = unique_sync_key("presenter_follower");
+        let sync_path = sync_path_owned.as_str();
 
         let mk_slides = || {
             vec![
@@ -685,7 +701,8 @@ mod tests {
     fn presenter_sync_with_bullet_reveals() {
         use crate::sync::SyncFile;
 
-        let sync_path = "/__deck_test_sync_bullet_reveal__";
+        let sync_path_owned = unique_sync_key("bullet_reveal");
+        let sync_path = sync_path_owned.as_str();
 
         let mk_slides = || {
             vec![

--- a/src/background.rs
+++ b/src/background.rs
@@ -683,23 +683,21 @@ mod tests {
     fn value_noise_in_range() {
         for i in 0..100 {
             let v = value_noise(i as f64 * 0.1, i as f64 * 0.2);
-            assert!(v >= 0.0 && v <= 1.0, "noise({}) = {}", i, v);
+            assert!((0.0..=1.0).contains(&v), "noise({i}) = {v}");
         }
     }
 
     fn check_cell_fn(f: fn(u16, u16, u16, u16, f64) -> (char, f64), name: &str) {
         let (c1, b1) = f(10, 5, 80, 24, 1.0);
         let (c2, b2) = f(10, 5, 80, 24, 1.0);
-        assert_eq!(c1, c2, "{} not deterministic (char)", name);
-        assert_eq!(b1, b2, "{} not deterministic (brightness)", name);
+        assert_eq!(c1, c2, "{name} not deterministic (char)");
+        assert_eq!(b1, b2, "{name} not deterministic (brightness)");
         for x in (0..80).step_by(10) {
             for y in (0..24).step_by(6) {
                 let (_, b) = f(x, y, 80, 24, 0.5);
                 assert!(
-                    b >= 0.0 && b <= 1.0,
-                    "{} brightness {} out of range",
-                    name,
-                    b
+                    (0.0..=1.0).contains(&b),
+                    "{name} brightness {b} out of range",
                 );
             }
         }

--- a/src/bigtext.rs
+++ b/src/bigtext.rs
@@ -436,11 +436,14 @@ fn render_with<const N: usize>(
     glyph_fn: fn(char) -> Option<[&'static str; N]>,
     rows: usize,
 ) -> Vec<String> {
-    let glyphs: Vec<[&str; N]> = text.chars().filter_map(glyph_fn).collect();
-
-    if glyphs.is_empty() {
-        return vec![text.to_uppercase()];
-    }
+    // Collect with `map` (not `filter_map`) so a single missing glyph forces
+    // the whole title into the plain-text fallback. Otherwise we'd silently
+    // drop unsupported chars (e.g. "café" → "cafe", missing the é).
+    let glyphs: Option<Vec<[&str; N]>> = text.chars().map(glyph_fn).collect();
+    let glyphs = match glyphs {
+        Some(g) if !g.is_empty() => g,
+        _ => return vec![text.to_uppercase()],
+    };
 
     (0..rows)
         .map(|row| glyphs.iter().map(|g| g[row]).collect::<Vec<_>>().join(" "))
@@ -508,5 +511,13 @@ mod tests {
         assert!(glyph_block('~').is_none());
         assert!(glyph_block('(').is_none());
         assert!(glyph_large('~').is_none());
+    }
+
+    #[test]
+    fn partial_unsupported_falls_back_to_plain() {
+        // Previously: `café` rendered as `CAFE` with the é silently dropped.
+        // Now: any unmapped char trips the plain-text fallback.
+        let lines = render("café", FontStyle::Block);
+        assert_eq!(lines, vec!["CAFÉ"]);
     }
 }

--- a/src/entrance.rs
+++ b/src/entrance.rs
@@ -56,6 +56,12 @@ pub struct EntranceTracker {
     current_slide: usize,
 }
 
+impl Default for EntranceTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl EntranceTracker {
     pub fn new() -> Self {
         Self {
@@ -113,8 +119,11 @@ pub fn apply_decrypt(frame: &mut Frame, rect: Rect, progress: f64, theme: &Theme
         for x in rect.x..rect.x + rect.width {
             if rng.next_f64() > progress {
                 if let Some(cell) = buf.cell_mut((x, y)) {
-                    let sym = cell.symbol().to_string();
-                    if sym != " " {
+                    // Skip blank cells AND wide-grapheme continuation cells
+                    // (whose `symbol()` is `""`) — overwriting the second cell of
+                    // a wide character corrupts the rendering.
+                    let sym = cell.symbol();
+                    if !sym.is_empty() && sym != " " {
                         let ch = GLITCH_CHARS[rng.next() as usize % GLITCH_CHARS.len()];
                         cell.set_char(ch);
                         cell.set_style(Style::default().fg(theme.accent).bg(theme.bg));

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -6,10 +7,13 @@ use syntect::highlighting::{FontStyle, Theme as SynTheme, ThemeSet};
 use syntect::parsing::SyntaxSet;
 
 /// Syntax highlighter backed by syntect. Caches results per (code, lang) pair.
+///
+/// Cache values are wrapped in `Arc` so cache hits are a refcount bump
+/// rather than a deep clone of every line and span.
 pub struct Highlighter {
     syntax_set: SyntaxSet,
     theme: SynTheme,
-    cache: HashMap<(u64, String), Vec<Line<'static>>>,
+    cache: HashMap<(String, String), Arc<Vec<Line<'static>>>>,
 }
 
 impl Highlighter {
@@ -33,11 +37,12 @@ impl Highlighter {
     }
 
     /// Highlight source code and return one `Line` per source line.
-    /// Results are cached per (code, lang) so repeated calls are free.
-    pub fn highlight(&mut self, code: &str, lang: &str) -> Vec<Line<'static>> {
-        let key = (hash_str(code), lang.to_string());
+    /// Results are cached per `(code, lang)`. Returns an `Arc` so repeated
+    /// calls (typewriter animation, multiple frames) are cheap refcount bumps.
+    pub fn highlight(&mut self, code: &str, lang: &str) -> Arc<Vec<Line<'static>>> {
+        let key = (code.to_string(), lang.to_string());
         if let Some(cached) = self.cache.get(&key) {
-            return cached.clone();
+            return Arc::clone(cached);
         }
 
         let syntax = self
@@ -59,19 +64,16 @@ impl Highlighter {
             })
             .collect();
 
-        self.cache.insert(key.clone(), lines.clone());
-        lines
+        let arc = Arc::new(lines);
+        self.cache.insert(key, Arc::clone(&arc));
+        arc
     }
 }
 
-/// Simple FNV-1a hash for cache keys.
-fn hash_str(s: &str) -> u64 {
-    let mut h: u64 = 0xcbf29ce484222325;
-    for b in s.bytes() {
-        h ^= b as u64;
-        h = h.wrapping_mul(0x100000001b3);
+impl Default for Highlighter {
+    fn default() -> Self {
+        Self::new()
     }
-    h
 }
 
 fn to_ratatui(style: syntect::highlighting::Style) -> Style {
@@ -157,5 +159,15 @@ mod tests {
         let lines2 = h.highlight("fn foo() {}", "rs");
         assert_eq!(lines1.len(), lines2.len());
         assert_eq!(h.cache.len(), 1);
+        // Both handles point at the same Arc — refcount-bump on hit.
+        assert!(Arc::ptr_eq(&lines1, &lines2));
+    }
+
+    #[test]
+    fn highlight_distinct_code_distinct_cache_entries() {
+        let mut h = Highlighter::new();
+        let _ = h.highlight("fn a() {}", "rs");
+        let _ = h.highlight("fn b() {}", "rs");
+        assert_eq!(h.cache.len(), 2);
     }
 }

--- a/src/image_renderer.rs
+++ b/src/image_renderer.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fmt::Write as FmtWrite;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -18,29 +18,103 @@ pub enum ImageProtocol {
     HalfBlocks,
 }
 
-/// Cached images keyed by (path, target_cols, target_rows).
-/// Stores already-resized images so resize only happens once per size.
+/// Cap on decoded image dimensions and allocation, to defuse decompression
+/// bombs in attacker-controlled image files.
+const MAX_IMAGE_DIM: u32 = 8192;
+
+/// FIFO-evicted cache. Insertion order is tracked so we never thrash the whole
+/// cache on overflow — only the oldest entry is dropped.
+struct FifoCache<K, V> {
+    map: HashMap<K, V>,
+    order: VecDeque<K>,
+    capacity: usize,
+}
+
+impl<K: std::hash::Hash + Eq + Clone, V> FifoCache<K, V> {
+    fn new(capacity: usize) -> Self {
+        Self {
+            map: HashMap::new(),
+            order: VecDeque::new(),
+            capacity,
+        }
+    }
+
+    fn get(&self, k: &K) -> Option<&V> {
+        self.map.get(k)
+    }
+
+    fn contains(&self, k: &K) -> bool {
+        self.map.contains_key(k)
+    }
+
+    fn insert(&mut self, k: K, v: V) {
+        while self.map.len() >= self.capacity {
+            if let Some(old) = self.order.pop_front() {
+                self.map.remove(&old);
+            } else {
+                break;
+            }
+        }
+        self.order.push_back(k.clone());
+        self.map.insert(k, v);
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.map.len()
+    }
+}
+
+/// Cache key keyed by raw `src` string (skips per-frame canonicalize).
+type ResizedKey = (String, u16, u16);
+
+/// Cached images keyed by `(src, target_cols, target_rows)`.
+/// Stores already-resized images so resize/decode happens once per size.
 pub struct ImageCache {
-    /// Original decoded images keyed by path.
-    originals: HashMap<String, Arc<RgbaImage>>,
-    /// Resized images keyed by (path, cols, rows).
-    resized: HashMap<(String, u16, u16), Arc<RgbaImage>>,
-    /// Pre-encoded Kitty base64 PNG keyed by (path, cols, rows).
-    encoded: HashMap<(String, u16, u16), String>,
-    /// Maximum number of resized entries before eviction.
-    max_resized: usize,
+    /// Original decoded images keyed by raw src string.
+    originals: FifoCache<String, Arc<RgbaImage>>,
+    /// Resized images keyed by (src, cols, rows).
+    resized: FifoCache<ResizedKey, Arc<RgbaImage>>,
+    /// Pre-encoded Kitty base64 PNG keyed by (src, cols, rows).
+    encoded: FifoCache<ResizedKey, String>,
+    /// `src` strings that have already passed the path-traversal check.
+    /// Avoids re-running canonicalize on every cache hit.
+    validated: HashMap<String, ()>,
 }
 
 const DEFAULT_MAX_RESIZED: usize = 64;
+const DEFAULT_MAX_ORIGINALS: usize = 16;
+const DEFAULT_MAX_ENCODED: usize = 64;
 
 impl ImageCache {
     pub fn new() -> Self {
         Self {
-            originals: HashMap::new(),
-            resized: HashMap::new(),
-            encoded: HashMap::new(),
-            max_resized: DEFAULT_MAX_RESIZED,
+            originals: FifoCache::new(DEFAULT_MAX_ORIGINALS),
+            resized: FifoCache::new(DEFAULT_MAX_RESIZED),
+            encoded: FifoCache::new(DEFAULT_MAX_ENCODED),
+            validated: HashMap::new(),
         }
+    }
+
+    /// Resolve and validate `src`. Absolute paths are trusted (the user
+    /// explicitly typed them); relative paths are sandboxed to `base_dir`.
+    /// Returns the canonicalized path on success.
+    fn resolve_and_validate(&mut self, src: &str, base_dir: &Path) -> Option<PathBuf> {
+        if self.validated.contains_key(src) {
+            // Already validated this exact src in a prior call.
+            // We still need the resolved path; recompute (cheap if cached at OS level).
+            return resolve(src, base_dir);
+        }
+        let resolved = resolve(src, base_dir)?;
+        let is_absolute = Path::new(src).is_absolute();
+        if !is_absolute {
+            let base = base_dir.canonicalize().ok()?;
+            if !resolved.starts_with(&base) {
+                return None;
+            }
+        }
+        self.validated.insert(src.to_string(), ());
+        Some(resolved)
     }
 
     /// Load, resize, and cache an image for the given area dimensions.
@@ -52,71 +126,76 @@ impl ImageCache {
         max_cols: u16,
         max_rows: u16,
     ) -> Option<&Arc<RgbaImage>> {
-        let full_path = if Path::new(src).is_absolute() {
-            PathBuf::from(src)
-        } else {
-            base_dir.join(src)
-        };
+        let key: ResizedKey = (src.to_string(), max_cols, max_rows);
 
-        // Path traversal guard: resolved path must stay within base_dir
-        let resolved = full_path.canonicalize().ok()?;
-        let base = base_dir.canonicalize().ok()?;
-        if !resolved.starts_with(&base) {
-            return None;
+        if self.resized.contains(&key) {
+            return self.resized.get(&key);
         }
 
-        let key = resolved.to_string_lossy().to_string();
-        let cache_key = (key.clone(), max_cols, max_rows);
+        // Cache miss: validate path, decode if needed, resize.
+        let resolved = self.resolve_and_validate(src, base_dir)?;
 
-        if self.resized.contains_key(&cache_key) {
-            return self.resized.get(&cache_key);
+        if !self.originals.contains(&src.to_string()) {
+            let img = decode_with_limits(&resolved)?;
+            self.originals.insert(src.to_string(), Arc::new(img));
         }
 
-        // Evict if cache is too large
-        if self.resized.len() >= self.max_resized {
-            self.resized.clear();
-            self.encoded.clear();
-        }
-
-        // Decode original if not cached
-        if !self.originals.contains_key(&key) {
-            let img = image::open(&resolved).ok()?;
-            self.originals.insert(key.clone(), Arc::new(img.to_rgba8()));
-        }
-
-        let original = self.originals.get(&key)?;
-        let resized = resize_to_fit(original, max_cols, max_rows);
-        self.resized.insert(cache_key.clone(), Arc::new(resized));
-        self.resized.get(&cache_key)
+        let original = self.originals.get(&src.to_string())?.clone();
+        let resized = resize_to_fit(&original, max_cols, max_rows);
+        self.resized.insert(key.clone(), Arc::new(resized));
+        self.resized.get(&key)
     }
 
     /// Get pre-encoded Kitty base64 PNG for a cached resized image.
-    /// Computes and caches on first call for each (path, cols, rows).
+    /// Computes and caches on first call for each (src, cols, rows).
     pub fn get_encoded_kitty(
         &mut self,
         src: &str,
-        base_dir: &Path,
+        _base_dir: &Path,
         max_cols: u16,
         max_rows: u16,
     ) -> Option<&str> {
-        let full_path = if Path::new(src).is_absolute() {
-            PathBuf::from(src)
-        } else {
-            base_dir.join(src)
-        };
-        let resolved = full_path.canonicalize().ok()?;
-        let key = resolved.to_string_lossy().to_string();
-        let cache_key = (key, max_cols, max_rows);
+        let key: ResizedKey = (src.to_string(), max_cols, max_rows);
 
-        if self.encoded.contains_key(&cache_key) {
-            return self.encoded.get(&cache_key).map(|s| s.as_str());
+        if self.encoded.contains(&key) {
+            return self.encoded.get(&key).map(|s| s.as_str());
         }
 
-        let img = self.resized.get(&cache_key)?;
+        let img = self.resized.get(&key)?;
         let b64 = encode_kitty_png(img)?;
-        self.encoded.insert(cache_key.clone(), b64);
-        self.encoded.get(&cache_key).map(|s| s.as_str())
+        self.encoded.insert(key.clone(), b64);
+        self.encoded.get(&key).map(|s| s.as_str())
     }
+}
+
+impl Default for ImageCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn resolve(src: &str, base_dir: &Path) -> Option<PathBuf> {
+    let full_path = if Path::new(src).is_absolute() {
+        PathBuf::from(src)
+    } else {
+        base_dir.join(src)
+    };
+    full_path.canonicalize().ok()
+}
+
+/// Decode an image with conservative dimension limits to defuse decompression
+/// bombs. Falls back to None on any decode error.
+fn decode_with_limits(path: &Path) -> Option<RgbaImage> {
+    let mut reader = image::ImageReader::open(path)
+        .ok()?
+        .with_guessed_format()
+        .ok()?;
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(MAX_IMAGE_DIM);
+    limits.max_image_height = Some(MAX_IMAGE_DIM);
+    reader.limits(limits);
+    let img = reader.decode().ok()?;
+    Some(img.to_rgba8())
 }
 
 /// Encode RGBA image to PNG then base64 for Kitty protocol.
@@ -392,8 +471,8 @@ mod tests {
     #[test]
     fn image_cache_new_is_empty() {
         let cache = ImageCache::new();
-        assert!(cache.originals.is_empty());
-        assert!(cache.resized.is_empty());
+        assert_eq!(cache.originals.len(), 0);
+        assert_eq!(cache.resized.len(), 0);
     }
 
     #[test]
@@ -467,5 +546,16 @@ mod tests {
         let mut output = Vec::new();
         flush_deferred(&mut output, &images).unwrap();
         assert!(output.is_empty()); // HalfBlocks writes nothing
+    }
+
+    #[test]
+    fn fifo_cache_evicts_oldest() {
+        let mut c: FifoCache<u32, &'static str> = FifoCache::new(2);
+        c.insert(1, "a");
+        c.insert(2, "b");
+        c.insert(3, "c"); // evicts 1
+        assert!(c.get(&1).is_none());
+        assert_eq!(c.get(&2), Some(&"b"));
+        assert_eq!(c.get(&3), Some(&"c"));
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -87,10 +87,17 @@ pub fn parse_deck(input: &str) -> Deck {
 }
 
 fn extract_frontmatter(input: &str) -> (DeckMeta, String) {
-    let trimmed = input.trim_start();
+    // Normalize CRLF so Windows-authored markdown (or files checked out with
+    // `core.autocrlf=true`) parses identically to LF.
+    let normalized = if input.contains("\r\n") {
+        input.replace("\r\n", "\n")
+    } else {
+        input.to_string()
+    };
+    let trimmed = normalized.trim_start();
     let after_first = match trimmed.strip_prefix("---") {
         Some(rest) => rest,
-        None => return (DeckMeta::default(), input.to_string()),
+        None => return (DeckMeta::default(), normalized.clone()),
     };
     let after_first = after_first.trim_start_matches(['\n', '\r']);
 
@@ -103,7 +110,7 @@ fn extract_frontmatter(input: &str) -> (DeckMeta, String) {
         }
     }
 
-    (DeckMeta::default(), input.to_string())
+    (DeckMeta::default(), normalized)
 }
 
 fn split_slides(body: &str) -> Vec<String> {
@@ -372,5 +379,15 @@ mod tests {
         let input = "<!-- background: fire -->\n# Title";
         let deck = parse_deck(input);
         assert!(deck.slides[0].background.is_none());
+    }
+
+    #[test]
+    fn frontmatter_with_crlf_line_endings() {
+        // Simulates a file authored on Windows or checked out with autocrlf.
+        let input = "---\r\ntitle = \"Hello\"\r\ntheme = \"minimal\"\r\n---\r\n# Slide 1";
+        let deck = parse_deck(input);
+        assert_eq!(deck.meta.title, "Hello");
+        assert!(matches!(deck.meta.theme, ThemeName::Minimal));
+        assert_eq!(deck.slides.len(), 1);
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -176,8 +176,11 @@ fn render_blocks(
                         bullet_rect,
                     );
 
-                    // Cascade entrance: fixed 300ms animation per bullet, staggered start
-                    let cascade_idx = block_idx * 100 + item_i;
+                    // Cascade entrance: fixed 300ms animation per bullet, staggered start.
+                    // Encode (block_idx, item_i) into a single key. 10_000 leaves headroom for
+                    // bullet lists with up to 9_999 items per block — far beyond realistic decks.
+                    debug_assert!(item_i < 10_000, "bullet list exceeds cascade-idx capacity");
+                    let cascade_idx = block_idx * 10_000 + item_i;
                     let stagger = std::time::Duration::from_millis(80 * item_i as u64);
                     let anim_dur = std::time::Duration::from_millis(300);
                     if let Some(state) = ctx.entrances.get_or_start(
@@ -240,7 +243,10 @@ fn apply_entrance_for_block(
             EntranceKind::Decrypt => entrance::apply_decrypt(frame, rect, progress, theme),
             EntranceKind::SlideIn => entrance::apply_slide_in(frame, rect, progress, theme),
             EntranceKind::FadeIn => entrance::apply_fade_in(frame, rect, progress, theme),
-            _ => {}
+            // Cascade and Typewriter are dispatched by their owning render paths
+            // (bullet-list and code-block). Keep the match exhaustive so adding a
+            // new EntranceKind is a compile error rather than a silent no-op.
+            EntranceKind::Cascade | EntranceKind::Typewriter => {}
         }
     }
 }
@@ -345,11 +351,12 @@ fn render_block(
                 None => (total_lines, 1.0),
             };
 
-            // Build visible lines with optional partial last line + cursor
+            // Build visible lines with optional partial last line + cursor.
+            // `highlighted` is an Arc — iterate by reference and clone only what we use.
             let mut lines: Vec<Line<'static>> = Vec::with_capacity(inner_height as usize);
-            for (i, hl) in highlighted.into_iter().enumerate() {
+            for (i, hl) in highlighted.iter().enumerate() {
                 if i < visible_lines {
-                    lines.push(hl);
+                    lines.push(hl.clone());
                 } else if i == visible_lines && visible_lines < total_lines {
                     // Partially typed current line
                     let full_text: String = hl.spans.iter().map(|s| s.content.as_ref()).collect();
@@ -361,10 +368,10 @@ fn render_block(
                         // Truncate spans to chars_to_show characters
                         let mut partial_spans: Vec<RSpan<'static>> = Vec::new();
                         let mut chars_left = chars_to_show;
-                        for span in hl.spans {
+                        for span in &hl.spans {
                             let span_len = span.content.chars().count();
                             if chars_left >= span_len {
-                                partial_spans.push(span);
+                                partial_spans.push(span.clone());
                                 chars_left -= span_len;
                             } else {
                                 let truncated: String =

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -2,6 +2,8 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
+use crate::util::fnv1a;
+
 /// Tiny file-based sync between presenter and follower instances.
 /// The presenter writes `slide_index reveal_count` to a temp file.
 /// The follower polls it.
@@ -11,9 +13,15 @@ pub struct SyncFile {
 
 impl SyncFile {
     /// Derive a deterministic sync file path from the presentation file path.
-    /// Uses a user-private directory to prevent symlink attacks.
+    /// Canonicalizes first so `--present talk.md` and `--follow ./talk.md`
+    /// (or one absolute, one relative) connect to the same sync file.
+    /// Falls back to the raw path if the file doesn't exist yet.
     pub fn for_file(input_path: &str) -> Self {
-        let hash = simple_hash(input_path);
+        let canonical = fs::canonicalize(input_path)
+            .ok()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|| input_path.to_string());
+        let hash = fnv1a(&canonical);
         let dir = sync_dir();
         let _ = fs::create_dir_all(&dir);
         let path = dir.join(format!("deck-{hash:016x}.sync"));
@@ -71,22 +79,28 @@ fn sync_dir() -> PathBuf {
     std::env::temp_dir().join("deck")
 }
 
-fn simple_hash(s: &str) -> u64 {
-    let mut h: u64 = 0xcbf29ce484222325; // FNV offset basis
-    for b in s.bytes() {
-        h ^= b as u64;
-        h = h.wrapping_mul(0x100000001b3); // FNV prime
-    }
-    h
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Per-test unique key so parallel `cargo test` runs do not collide.
+    fn unique_key(label: &str) -> String {
+        format!(
+            "/__deck_test__{}__{}__{}__{}",
+            label,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+            line!(),
+        )
+    }
+
     #[test]
     fn write_read_roundtrip() {
-        let sync = SyncFile::for_file("/tmp/test-deck-roundtrip.md");
+        let key = unique_key("roundtrip");
+        let sync = SyncFile::for_file(&key);
         sync.write(5, 3);
         let result = sync.read();
         assert_eq!(result, Some((5, 3)));
@@ -95,7 +109,8 @@ mod tests {
 
     #[test]
     fn read_missing_file_returns_none() {
-        let sync = SyncFile::for_file("/tmp/nonexistent-deck-test.md");
+        let key = unique_key("missing");
+        let sync = SyncFile::for_file(&key);
         sync.cleanup(); // ensure clean state
         assert_eq!(sync.read(), None);
     }
@@ -116,7 +131,8 @@ mod tests {
 
     #[test]
     fn cleanup_removes_files() {
-        let sync = SyncFile::for_file("/tmp/test-deck-cleanup.md");
+        let key = unique_key("cleanup");
+        let sync = SyncFile::for_file(&key);
         sync.write(0, 0);
         assert!(sync.path.exists());
         sync.cleanup();
@@ -128,5 +144,18 @@ mod tests {
         let dir = sync_dir();
         // Should be inside a "deck" subdirectory, not directly in /tmp
         assert!(dir.ends_with("deck"));
+    }
+
+    #[test]
+    fn relative_and_absolute_resolve_to_same_path_when_canonicalizable() {
+        // Use a file that actually exists (Cargo.toml at the project root)
+        // so canonicalize() succeeds and equates the two forms.
+        let cwd = std::env::current_dir().expect("cwd");
+        let abs = cwd.join("Cargo.toml");
+        if abs.exists() {
+            let a = SyncFile::for_file("Cargo.toml");
+            let b = SyncFile::for_file(abs.to_str().unwrap());
+            assert_eq!(a.path, b.path, "canonicalize should equate paths");
+        }
     }
 }

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -171,7 +171,7 @@ mod tests {
         let mut rng = Rng::new(123);
         for _ in 0..1000 {
             let v = rng.next_f64();
-            assert!(v >= 0.0 && v < 1.0, "got {}", v);
+            assert!((0.0..1.0).contains(&v), "got {v}");
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,11 +1,17 @@
 /// Shared xorshift64 RNG used by transitions and entrance animations.
+///
+/// Deterministic: the same seed always produces the same sequence. Suitable for
+/// per-frame visual randomness, not cryptography.
 pub struct Rng(u64);
 
 impl Rng {
+    /// Construct from any seed. The low bit is forced on so seed 0 is not
+    /// stuck producing zeros.
     pub fn new(seed: u64) -> Self {
         Self(seed | 1)
     }
 
+    /// Next 64-bit pseudorandom value.
     pub fn next(&mut self) -> u64 {
         self.0 ^= self.0 << 13;
         self.0 ^= self.0 >> 7;
@@ -13,12 +19,51 @@ impl Rng {
         self.0
     }
 
+    /// Next f64 in `[0.0, 1.0)`. Uses the top 53 bits of `next()` to fill the
+    /// f64 mantissa — full entropy, no modulo bias.
     pub fn next_f64(&mut self) -> f64 {
-        (self.next() % 10000) as f64 / 10000.0
+        (self.next() >> 11) as f64 / (1u64 << 53) as f64
     }
 }
 
+/// Glitch character palette used by decrypt entrances and glitch transitions.
 pub const GLITCH_CHARS: &[char] = &[
     '!', '@', '#', '$', '%', '^', '&', '*', '<', '>', '{', '}', '[', ']', '|', '/', '\\', '~', '░',
     '▒', '▓', '█', '▄', '▀', '▌', '▐',
 ];
+
+/// FNV-1a 64-bit hash. Used for cache keys where collisions are tolerable
+/// (we fall back to a recompute on miss). Not cryptographic.
+pub fn fnv1a(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in s.bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_f64_in_unit_range() {
+        let mut rng = Rng::new(123);
+        for _ in 0..1000 {
+            let v = rng.next_f64();
+            assert!((0.0..1.0).contains(&v), "got {v}");
+        }
+    }
+
+    #[test]
+    fn fnv1a_is_deterministic() {
+        assert_eq!(fnv1a("hello"), fnv1a("hello"));
+        assert_ne!(fnv1a("hello"), fnv1a("world"));
+    }
+
+    #[test]
+    fn fnv1a_empty_is_offset_basis() {
+        assert_eq!(fnv1a(""), 0xcbf29ce484222325);
+    }
+}


### PR DESCRIPTION
Closes #21

## Summary

- **Critical**: canonicalize sync paths so `--present`/`--follow` connect across CWDs and absolute/relative path forms
- **Critical**: allow user-supplied absolute image paths (sandbox still applies to relative paths)
- **Critical**: cap decoded image dimensions via `image::Limits` to defuse decompression-bomb DoS
- **Perf**: highlight cache returns `Arc<Vec<Line>>` (refcount-bump on hit); image cache keyed by raw `src` so frames skip per-frame `canonicalize` syscalls; FIFO eviction
- **Correctness**: CRLF frontmatter; decrypt entrance protects wide-grapheme continuation cells; bigtext falls back to plain text when any char lacks a glyph
- **Hardening**: defensive `saturating_sub(1)` on `slides.len()`; exhaustive `EntranceKind` match; cascade idx encoding widened
- **Internal**: shared `fnv1a` helper; `Rng::next_f64` uses 53-bit mantissa; `Default` impls; tests use unique sync paths
- **Docs**: `[Unreleased]` section in CHANGELOG; README dependency wording

## Test plan

- [x] `cargo check --all-targets` clean
- [x] `cargo test` — 175 passed (8 new tests; no regressions)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo build --release` clean
- [x] Smoke-test `examples/demo.md` in a Kitty/iTerm/half-block terminal
- [x] Verify `--present` + `--follow` connect with both relative and absolute path forms
- [x] Confirm `![logo](/usr/share/icons/...)` renders instead of falling back to the text label