### PR TITLE
Document public API surface and fix docstring drift

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -21,34 +21,76 @@ use crate::sync::SyncFile;
 use crate::theme::Theme;
 use crate::transition::{self, TransitionKind, TransitionState};
 
+/// Which UI layout the renderer uses.
+///
+/// Toggled with `p`. `Normal` shows full-screen slides; `Presenter` shows the
+/// current and next slide side-by-side with speaker notes and a timer.
 pub enum Mode {
     Normal,
     Presenter,
 }
 
+/// Top-level application state.
+///
+/// Owns the parsed deck, the navigation cursor (`slide_index` and
+/// `reveal_count`), the active theme, optional presenter/follower [`SyncFile`],
+/// image cache, transition + entrance animation state, and the syntect
+/// highlighter. Constructed once in `main` and driven by [`App::draw`],
+/// [`App::tick`], and [`App::handle_key`].
 pub struct App {
+    /// Parsed deck (frontmatter metadata + ordered slides).
     pub deck: Deck,
+    /// Index into `deck.slides` of the slide currently being shown.
     pub slide_index: usize,
+    /// Number of bullets revealed on the current slide. `usize::MAX` for slides
+    /// that contain no bullets — saturates so `advance` immediately moves to
+    /// the next slide.
     pub reveal_count: usize,
+    /// Active UI layout (full-screen vs. presenter view).
     pub mode: Mode,
+    /// True while the help overlay is visible.
     pub show_help: bool,
+    /// In-progress digit input for the `:N Enter` go-to command.
     pub goto_input: String,
+    /// True while the go-to overlay is accepting input.
     pub in_goto: bool,
+    /// Active slide-to-slide transition, if any.
     pub transition: Option<TransitionState>,
+    /// Process start time. Currently used for animated background phase.
     pub start: Instant,
+    /// Speaker timer; reset by the `r` key and rendered into the status bar.
     pub timer: Instant,
+    /// Color/font palette in use.
     pub theme: Theme,
+    /// Optional sync channel. When set, the presenter writes navigation state
+    /// here and a follower process reads it to mirror the slide.
     pub sync: Option<SyncFile>,
+    /// Read-only follower mode: navigation keys are ignored and `tick`
+    /// polls `sync` instead.
     pub is_follower: bool,
+    /// Best image protocol detected at startup.
     pub protocol: ImageProtocol,
+    /// Decoded/resized/encoded image cache, shared across frames.
     pub image_cache: ImageCache,
+    /// Per-frame queue of high-resolution images to flush to the terminal
+    /// after ratatui has finished writing the cell buffer. Cleared at the
+    /// start of every `draw`.
     pub deferred_images: Vec<DeferredImage>,
+    /// Sandbox root for relative image paths. Typically the directory
+    /// containing the markdown file.
     pub base_dir: PathBuf,
+    /// Cached syntect highlighter for fenced code blocks.
     pub highlighter: Highlighter,
+    /// Per-block entrance animation tracker. Reset on slide change.
     pub entrances: EntranceTracker,
 }
 
 impl App {
+    /// Build a fresh app rooted on the first slide.
+    ///
+    /// Panics if `deck.slides` is empty. `is_follower = true` makes this
+    /// instance read-only — it polls `sync` and ignores navigation keys.
+    /// `base_dir` is the sandbox root for relative image paths.
     pub fn new(
         deck: Deck,
         theme: Theme,
@@ -83,12 +125,15 @@ impl App {
         }
     }
 
+    /// True when the current slide has an animated background. The main loop
+    /// uses this to bump the redraw rate to ~30fps.
     pub fn has_active_background(&self) -> bool {
         self.deck.slides[self.slide_index].background.is_some()
     }
 
+    /// Remove the sync file on shutdown. No-op for followers; only the
+    /// presenter owns the file and is responsible for cleanup.
     pub fn cleanup_sync(&self) {
-        // Only the presenter cleans up the sync file
         if let Some(ref sync) = self.sync {
             if !self.is_follower {
                 sync.cleanup();
@@ -96,6 +141,11 @@ impl App {
         }
     }
 
+    /// Render one frame: slide content (or presenter pane), animated
+    /// background, transition overlay, status bar, and any active modal
+    /// (help / goto). Clears `deferred_images`; high-resolution image
+    /// protocols (Kitty/Sixel) are flushed by the caller after `draw`
+    /// returns.
     pub fn draw(&mut self, frame: &mut Frame) {
         self.deferred_images.clear();
         self.entrances.on_slide_change(self.slide_index);
@@ -180,7 +230,13 @@ impl App {
         }
     }
 
-    /// Returns true if the app should quit.
+    /// Process a key event and mutate slide/reveal/UI state. When navigation
+    /// occurs the new position is also written to the sync file (presenter
+    /// only). In follower mode every key except quit is ignored.
+    ///
+    /// Returns true only when the app should fully exit. `Quit` first
+    /// dismisses the help overlay or goto buffer if either is active, and
+    /// only quits on the next press.
     pub fn handle_key(&mut self, key: crossterm::event::KeyEvent) -> bool {
         // Follower mode: only allow quit
         if self.is_follower {
@@ -245,6 +301,10 @@ impl App {
         false
     }
 
+    /// Per-frame housekeeping: clear finished transitions and, in follower
+    /// mode, read the sync file to mirror the presenter's slide and reveal
+    /// index. Transitions are started for slide changes only, not reveal-only
+    /// updates.
     pub fn tick(&mut self) {
         if let Some(ref trans) = self.transition {
             if trans.is_done() {

--- a/src/entrance.rs
+++ b/src/entrance.rs
@@ -63,6 +63,8 @@ impl Default for EntranceTracker {
 }
 
 impl EntranceTracker {
+    /// Construct an empty tracker with no active slide. The first call to
+    /// `on_slide_change` will not purge anything (there's nothing to purge).
     pub fn new() -> Self {
         Self {
             states: HashMap::new(),
@@ -70,7 +72,11 @@ impl EntranceTracker {
         }
     }
 
-    /// Called when a slide changes — purges old animations.
+    /// Notify the tracker of the active slide.
+    ///
+    /// If `slide` differs from the previously tracked slide, all in-flight
+    /// animations are purged. Safe to call every frame: a no-op when the
+    /// slide hasn't changed.
     pub fn on_slide_change(&mut self, slide: usize) {
         if slide != self.current_slide {
             self.states.clear();
@@ -79,7 +85,12 @@ impl EntranceTracker {
     }
 
     /// Get entrance state for a block, creating a new animation if first seen.
-    /// Returns None if the animation is already finished (no need to apply effects).
+    /// Returns `None` if the animation is already finished (no need to apply
+    /// effects).
+    ///
+    /// `kind` and `duration` are only used when creating a new state; on
+    /// subsequent calls for the same `(slide, block_idx)` they are ignored
+    /// and the existing state is returned.
     pub fn get_or_start(
         &mut self,
         slide: usize,

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -17,6 +17,8 @@ pub struct Highlighter {
 }
 
 impl Highlighter {
+    /// Construct a highlighter with the bundled syntax set and the
+    /// `base16-ocean.dark` color theme.
     pub fn new() -> Self {
         let syntax_set = SyntaxSet::load_defaults_newlines();
         let theme_set = ThemeSet::load_defaults();

--- a/src/image_renderer.rs
+++ b/src/image_renderer.rs
@@ -22,8 +22,10 @@ pub enum ImageProtocol {
 /// bombs in attacker-controlled image files.
 const MAX_IMAGE_DIM: u32 = 8192;
 
-/// FIFO-evicted cache. Insertion order is tracked so we never thrash the whole
-/// cache on overflow — only the oldest entry is dropped.
+/// FIFO-evicted cache. Insertion order is tracked so we never thrash the
+/// whole cache on overflow. On `insert`, oldest entries are popped one at a
+/// time until `len < capacity`; in steady state with a fixed capacity this
+/// drops exactly one entry per insert.
 struct FifoCache<K, V> {
     map: HashMap<K, V>,
     order: VecDeque<K>,
@@ -65,20 +67,29 @@ impl<K: std::hash::Hash + Eq + Clone, V> FifoCache<K, V> {
     }
 }
 
-/// Cache key keyed by raw `src` string (skips per-frame canonicalize).
+/// Cache key keyed by the raw `src` string. Avoids canonicalizing the path
+/// on every frame's lookup; canonicalize only runs on cache miss to validate
+/// the path.
 type ResizedKey = (String, u16, u16);
 
-/// Cached images keyed by `(src, target_cols, target_rows)`.
-/// Stores already-resized images so resize/decode happens once per size.
+/// Multi-tier image cache.
+///
+/// - `originals`: decoded RGBA images keyed by raw `src`
+/// - `resized`: resized images keyed by `(src, cols, rows)`
+/// - `encoded`: pre-encoded Kitty base64 PNG keyed by `(src, cols, rows)`
+/// - `validated`: set of `src` strings that have already passed the
+///   path-traversal check
+///
+/// Each tier is FIFO-evicted independently. Decode + resize + encode each
+/// happen at most once per unique key.
 pub struct ImageCache {
-    /// Original decoded images keyed by raw src string.
     originals: FifoCache<String, Arc<RgbaImage>>,
-    /// Resized images keyed by (src, cols, rows).
     resized: FifoCache<ResizedKey, Arc<RgbaImage>>,
-    /// Pre-encoded Kitty base64 PNG keyed by (src, cols, rows).
     encoded: FifoCache<ResizedKey, String>,
     /// `src` strings that have already passed the path-traversal check.
-    /// Avoids re-running canonicalize on every cache hit.
+    /// Avoids re-running the `base_dir.canonicalize()` + `starts_with` check
+    /// on every cache hit. The `src` itself is still re-canonicalized via
+    /// `resolve()` on hit to recover the resolved path.
     validated: HashMap<String, ()>,
 }
 
@@ -87,6 +98,8 @@ const DEFAULT_MAX_ORIGINALS: usize = 16;
 const DEFAULT_MAX_ENCODED: usize = 64;
 
 impl ImageCache {
+    /// Construct an empty cache with the default capacities (16 originals,
+    /// 64 resized, 64 encoded).
     pub fn new() -> Self {
         Self {
             originals: FifoCache::new(DEFAULT_MAX_ORIGINALS),
@@ -97,12 +110,16 @@ impl ImageCache {
     }
 
     /// Resolve and validate `src`. Absolute paths are trusted (the user
-    /// explicitly typed them); relative paths are sandboxed to `base_dir`.
-    /// Returns the canonicalized path on success.
+    /// explicitly typed them) and bypass the sandbox check; relative paths
+    /// are sandboxed to `base_dir`. Returns the canonicalized path on success.
+    ///
+    /// The first call for a given `src` runs the full sandbox check; later
+    /// calls for the same `src` short-circuit via the `validated` set and
+    /// re-resolve the path only. The `validated` set is never invalidated,
+    /// so renaming or moving `base_dir` after first validation is not
+    /// detected.
     fn resolve_and_validate(&mut self, src: &str, base_dir: &Path) -> Option<PathBuf> {
         if self.validated.contains_key(src) {
-            // Already validated this exact src in a prior call.
-            // We still need the resolved path; recompute (cheap if cached at OS level).
             return resolve(src, base_dir);
         }
         let resolved = resolve(src, base_dir)?;
@@ -118,7 +135,10 @@ impl ImageCache {
     }
 
     /// Load, resize, and cache an image for the given area dimensions.
-    /// Returns None if the file can't be read/decoded or path escapes base_dir.
+    /// Returns `None` if the file can't be read or decoded.
+    ///
+    /// Relative `src` paths are sandboxed to `base_dir`; absolute paths are
+    /// trusted (user-typed) and bypass the sandbox check.
     pub fn get_resized(
         &mut self,
         src: &str,
@@ -147,7 +167,10 @@ impl ImageCache {
     }
 
     /// Get pre-encoded Kitty base64 PNG for a cached resized image.
-    /// Computes and caches on first call for each (src, cols, rows).
+    /// Computes and caches on first call for each `(src, cols, rows)`.
+    /// Returns `None` if no resized image has been cached for this key
+    /// (caller must invoke `get_resized` first), or if PNG encoding fails.
+    /// `_base_dir` is unused — kept for symmetry with `get_resized`.
     pub fn get_encoded_kitty(
         &mut self,
         src: &str,
@@ -330,7 +353,9 @@ pub fn flush_deferred<W: Write>(w: &mut W, images: &[DeferredImage]) -> std::io:
     Ok(())
 }
 
-/// Kitty Graphics Protocol: send pre-encoded base64 PNG in APC escape.
+/// Kitty Graphics Protocol: send pre-encoded base64 PNG in an APC escape.
+/// No-op (returns Ok) if `d.kitty_b64` is `None` — caller is expected to
+/// have populated it via [`ImageCache::get_encoded_kitty`].
 fn render_kitty<W: Write>(w: &mut W, d: &DeferredImage) -> std::io::Result<()> {
     let b64 = match d.kitty_b64 {
         Some(ref s) => s,

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,10 @@
 use crossterm::event::{KeyCode, KeyEvent};
 
+/// Logical action a key event maps to.
+///
+/// Decouples crossterm key codes from `App`'s state machine. `GoTo*` variants
+/// are only emitted while the app is in goto-input mode (see `map_key`'s
+/// `in_goto` flag).
 pub enum Action {
     Next,
     Prev,
@@ -17,6 +22,10 @@ pub enum Action {
     None,
 }
 
+/// Map a crossterm key event to an [`Action`].
+///
+/// `in_goto` switches to the slide-number input keymap, where digits and
+/// `Backspace` edit the buffer and `Enter` / `Esc` confirm or cancel.
 pub fn map_key(key: KeyEvent, in_goto: bool) -> Action {
     if in_goto {
         return match key.code {

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,5 +1,9 @@
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Parser, Tag, TagEnd};
 
+/// One block of slide content.
+///
+/// The intermediate representation produced by [`parse_blocks`] and consumed
+/// by the render layer.
 #[derive(Debug, Clone)]
 pub enum Block {
     Heading { level: u8, text: String },
@@ -11,11 +15,14 @@ pub enum Block {
     Image { path: String, alt: String },
 }
 
+/// One item in a bullet or numbered list, holding inline spans.
 #[derive(Debug, Clone)]
 pub struct ListItem {
     pub spans: Vec<Span>,
 }
 
+/// Inline text fragment with style. Used inside paragraphs, headings, and list
+/// items to mix plain text with bold, italic, and inline-code runs.
 #[derive(Debug, Clone)]
 pub enum Span {
     Plain(String),
@@ -24,6 +31,10 @@ pub enum Span {
     Code(String),
 }
 
+/// Parse a markdown fragment into a flat list of blocks.
+///
+/// Wraps `pulldown-cmark`'s event stream into the deck IR the renderer
+/// expects. Nested lists are flattened: only the innermost items are kept.
 pub fn parse_blocks(markdown: &str) -> Vec<Block> {
     let parser = Parser::new(markdown);
     let mut blocks = Vec::new();

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,12 +5,17 @@ use crate::markdown::{self, Block};
 use crate::theme::ThemeName;
 use crate::transition::TransitionKind;
 
+/// A fully parsed presentation: TOML frontmatter (`meta`) plus ordered slides.
+///
+/// Produced by [`parse_deck`].
 #[derive(Debug)]
 pub struct Deck {
     pub meta: DeckMeta,
     pub slides: Vec<Slide>,
 }
 
+/// Deck-wide metadata read from a TOML frontmatter block at the top of the
+/// markdown file. All fields are optional and default when absent.
 #[derive(Debug, Deserialize)]
 pub struct DeckMeta {
     #[serde(default = "default_title")]
@@ -21,6 +26,8 @@ pub struct DeckMeta {
     pub theme: ThemeName,
     #[serde(default)]
     pub transition: TransitionKind,
+    /// Default animated background for the first slide. Per-slide overrides
+    /// (via `<!-- background: ... -->`) take precedence.
     #[serde(default)]
     pub background: Option<BackgroundKind>,
 }
@@ -41,21 +48,31 @@ impl Default for DeckMeta {
     }
 }
 
+/// One slide: ordered blocks plus optional layout/columns/notes/background.
 #[derive(Debug)]
 pub struct Slide {
     pub blocks: Vec<Block>,
     pub layout: Layout,
+    /// Side-by-side body when `layout == Columns`. Any leading blocks above
+    /// the `::: columns` marker live in `blocks` and render above the split.
     pub columns: Option<Columns>,
+    /// Speaker notes extracted from `<!-- note: ... -->` comments. Hidden in
+    /// normal mode; shown in presenter mode.
     pub notes: Vec<String>,
+    /// Per-slide animated background that overrides the deck-level default.
     pub background: Option<BackgroundKind>,
 }
 
+/// Two-column slide body: left and right block sequences rendered side-by-side.
 #[derive(Debug)]
 pub struct Columns {
     pub left: Vec<Block>,
     pub right: Vec<Block>,
 }
 
+/// How a slide's content is laid out. Selected by HTML-comment directives in
+/// markdown: `<!-- layout: center -->` for `Center`, a `::: columns` block for
+/// `Columns`. Drives renderer dispatch in [`crate::render::render_slide`].
 #[derive(Debug, Default)]
 pub enum Layout {
     #[default]
@@ -64,6 +81,14 @@ pub enum Layout {
     Columns,
 }
 
+/// Parse a markdown deck.
+///
+/// Extracts an optional TOML frontmatter (`---`-fenced), splits the body on
+/// `---` separators, parses each slide's blocks, and applies the deck-level
+/// background to the first slide if it doesn't already have one.
+///
+/// Always returns a `Deck`; malformed frontmatter falls back to defaults
+/// rather than erroring.
 pub fn parse_deck(input: &str) -> Deck {
     let (meta, body) = extract_frontmatter(input);
     let raw_slides = split_slides(&body);

--- a/src/render.rs
+++ b/src/render.rs
@@ -18,7 +18,10 @@ use crate::markdown::{Block, Span};
 use crate::parse::{Layout, Slide};
 use crate::theme::Theme;
 
-/// Shared rendering context to avoid passing many parameters individually.
+/// Shared per-frame rendering context bundling all state the slide renderer
+/// reads or mutates: image protocol + cache, deferred-render queue, sandbox
+/// base dir, syntax highlighter, entrance-animation tracker, and the index of
+/// the slide currently being drawn (used as the entrance-tracker key).
 pub struct RenderCtx<'a> {
     pub protocol: ImageProtocol,
     pub image_cache: &'a mut ImageCache,
@@ -29,6 +32,11 @@ pub struct RenderCtx<'a> {
     pub slide_index: usize,
 }
 
+/// Draw one slide into `area`.
+///
+/// Dispatches on `slide.layout` (default, vertically centered, or two-column).
+/// `reveal` is the number of bullets to show; pass `usize::MAX` for previews
+/// or for slides without bullets.
 pub fn render_slide(
     frame: &mut Frame,
     area: Rect,
@@ -90,6 +98,11 @@ pub fn render_slide(
     }
 }
 
+/// Draw the bottom status bar.
+///
+/// Layout: deck title (and optional author) on the left, slide counter
+/// centered, elapsed `mm:ss` timer on the right. Padding between segments is
+/// filled with `─` glyphs.
 #[allow(clippy::too_many_arguments)]
 pub fn render_status_bar(
     frame: &mut Frame,

--- a/src/render_presenter.rs
+++ b/src/render_presenter.rs
@@ -11,6 +11,9 @@ use crate::parse::Deck;
 use crate::render::{self, RenderCtx};
 use crate::theme::Theme;
 
+/// Render the presenter view: a 70/30 vertical split with the current and
+/// next slide on top (65/35 horizontal split), and speaker notes plus the
+/// elapsed timer on the bottom.
 #[allow(clippy::too_many_arguments)]
 pub fn render_presenter(
     frame: &mut Frame,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -15,7 +15,8 @@ impl SyncFile {
     /// Derive a deterministic sync file path from the presentation file path.
     /// Canonicalizes first so `--present talk.md` and `--follow ./talk.md`
     /// (or one absolute, one relative) connect to the same sync file.
-    /// Falls back to the raw path if the file doesn't exist yet.
+    /// Falls back to the raw path string if canonicalize fails for any reason
+    /// (file not yet created, permission error, etc.).
     pub fn for_file(input_path: &str) -> Self {
         let canonical = fs::canonicalize(input_path)
             .ok()
@@ -29,6 +30,9 @@ impl SyncFile {
     }
 
     /// Write current state. Uses write-then-rename for atomicity.
+    /// All I/O errors are silently ignored — the sync channel is best-effort
+    /// and a failed write recovers on the next call. The temp file
+    /// (`<path>.tmp.<pid>`) is best-effort cleaned up on write failure.
     pub fn write(&self, slide: usize, reveal: usize) {
         let tmp = self.path.with_extension({
             let pid = std::process::id();
@@ -44,7 +48,9 @@ impl SyncFile {
         }
     }
 
-    /// Read current state from the sync file.
+    /// Read current state from the sync file. Returns `None` if the file is
+    /// missing, unreadable, malformed (fewer than two whitespace-separated
+    /// tokens), or contains values that don't parse as `usize`.
     pub fn read(&self) -> Option<(usize, usize)> {
         let content = fs::read_to_string(&self.path).ok()?;
         let mut parts = content.split_whitespace();

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -4,6 +4,10 @@ use serde::Deserialize;
 use crate::bigtext::FontStyle;
 use crate::transition::TransitionKind;
 
+/// Built-in theme variants.
+///
+/// Selectable via the `--theme` CLI flag or the `theme = "..."` frontmatter
+/// field. Mapped to a concrete [`Theme`] palette by [`Theme::from_name`].
 #[derive(Clone, Debug, Default, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum ThemeName {
@@ -14,6 +18,11 @@ pub enum ThemeName {
     Catppuccin,
 }
 
+/// Color palette and font/transition defaults used by the renderer.
+///
+/// Build from a [`ThemeName`] via [`Theme::from_name`]. Prefer the `*_style`
+/// accessors over reading the raw color fields directly; they bake in
+/// modifiers (`BOLD`, `ITALIC`) and the chosen background.
 pub struct Theme {
     pub bg: Color,
     pub fg: Color,
@@ -26,10 +35,12 @@ pub struct Theme {
     pub italic: Color,
     pub bullet: &'static str,
     pub font: FontStyle,
+    /// Slide-to-slide transition used when the deck doesn't override it.
     pub default_transition: TransitionKind,
 }
 
 impl Theme {
+    /// Build one of the built-in themes by name.
     pub fn from_name(name: &ThemeName) -> Self {
         match name {
             ThemeName::Hacker => Self::hacker(),
@@ -108,32 +119,39 @@ impl Theme {
         }
     }
 
+    /// Style for the H1 big-text glyphs. Currently aliases `heading_style`.
     pub fn h1_style(&self) -> Style {
         self.heading_style()
     }
 
+    /// Style for headings (H2+): `heading` color, bold.
     pub fn heading_style(&self) -> Style {
         Style::default()
             .fg(self.heading)
             .add_modifier(Modifier::BOLD)
     }
 
+    /// Style for normal body text: `fg` on `bg`.
     pub fn body_style(&self) -> Style {
         Style::default().fg(self.fg).bg(self.bg)
     }
 
+    /// Style for inline and fenced code: `code_fg` on `code_bg`.
     pub fn code_style(&self) -> Style {
         Style::default().fg(self.code_fg).bg(self.code_bg)
     }
 
+    /// Style for the border around fenced code blocks.
     pub fn code_border(&self) -> Style {
         Style::default().fg(self.dim)
     }
 
+    /// Style for the leading bullet glyph.
     pub fn bullet_style(&self) -> Style {
         Style::default().fg(self.accent)
     }
 
+    /// Style for `**bold**` runs: `bold` color with the `BOLD` modifier.
     pub fn bold_style(&self) -> Style {
         Style::default()
             .fg(self.bold)
@@ -141,6 +159,7 @@ impl Theme {
             .add_modifier(Modifier::BOLD)
     }
 
+    /// Style for `*italic*` runs: `italic` color with the `ITALIC` modifier.
     pub fn italic_style(&self) -> Style {
         Style::default()
             .fg(self.italic)
@@ -148,14 +167,17 @@ impl Theme {
             .add_modifier(Modifier::ITALIC)
     }
 
+    /// Style for horizontal rules: `dim` foreground.
     pub fn rule_style(&self) -> Style {
         Style::default().fg(self.dim)
     }
 
+    /// Status bar base style: `dim` on `bg`.
     pub fn status_style(&self) -> Style {
         Style::default().fg(self.dim).bg(self.bg)
     }
 
+    /// Accent style used inside the status bar (title and timer): `accent` on `bg`.
     pub fn status_accent(&self) -> Style {
         Style::default().fg(self.accent).bg(self.bg)
     }

--- a/src/transition.rs
+++ b/src/transition.rs
@@ -5,17 +5,28 @@ use serde::Deserialize;
 
 use crate::theme::Theme;
 
+/// Visual effect played when the slide changes.
+///
+/// `None` skips the overlay entirely. Each theme picks a default in
+/// `Theme::default_transition`; per-deck override comes from the
+/// `transition = "..."` frontmatter field.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TransitionKind {
     #[default]
     None,
+    /// Random characters gradually resolve into the slide content.
     Glitch,
+    /// Shade blocks fade out to reveal slide content.
     Fade,
+    /// Vertical bar sweeps left-to-right, revealing the new slide.
     Wipe,
+    /// Cell-by-cell dissolve with smoothstep easing.
     Dissolve,
 }
 
+/// Live state of an active transition: kind, when it started, and how long it
+/// should run (default 400ms).
 pub struct TransitionState {
     pub kind: TransitionKind,
     pub started: Instant,
@@ -23,6 +34,7 @@ pub struct TransitionState {
 }
 
 impl TransitionState {
+    /// Start a 400ms transition of the given kind, anchored to `Instant::now()`.
     pub fn new(kind: TransitionKind) -> Self {
         Self {
             kind,
@@ -31,6 +43,7 @@ impl TransitionState {
         }
     }
 
+    /// True once `started + duration` has elapsed.
     pub fn is_done(&self) -> bool {
         self.started.elapsed() >= self.duration
     }


### PR DESCRIPTION
Closes #23

## Summary
- Add rustdoc to `App` (+ 19 fields), `Mode`, `Deck`/`DeckMeta`/`Slide`/`Layout`, `Block`/`Span`/`ListItem`, `Theme`/`ThemeName` (+ 11 style accessors), `TransitionKind`/`TransitionState`, `Action`/`map_key`, `RenderCtx`, `render_slide`, `render_status_bar`, `render_presenter`, and constructors on `Highlighter`/`EntranceTracker`.
- Fix `App::handle_key` doc to cover follower-mode and the sync side effect; fix `sync.rs` doc on `for_file`/`write`/`read` to reflect actual error handling.
- Fix `image_renderer.rs` docs to describe the four-tier cache, absolute-path sandbox bypass, `get_encoded_kitty` precondition, `render_kitty` no-op, `FifoCache` eviction loop.
- Fix `entrance.rs` docs on `on_slide_change` (conditional purge) and `get_or_start` (kind/duration ignored on cache hit).

## Test plan
- [x] `cargo test --bin deck` — 175/175 pass
- [x] `cargo doc --no-deps` — no warnings
- [x] `cargo doc` with `-D rustdoc::broken-intra-doc-links` — passes
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean