### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-25
+
 ### Security
 - Cap decoded image dimensions and allocations to defuse decompression-bomb images
   in shared decks
@@ -27,6 +29,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   per-frame `canonicalize` syscalls
 - Image cache uses FIFO eviction (one entry at a time) instead of clearing
   the whole cache on overflow; originals are now bounded too
+
+### Documentation
+- Public API surface (App, Deck, Theme, render, transitions, input, etc.) now
+  carries rustdoc; existing docstrings updated to match post-refactor behavior
+  (sync error handling, image cache tiers, entrance-tracker semantics)
 
 ### Internal
 - Shared FNV-1a `fnv1a` helper in `util.rs`, replacing duplicated impls

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "deck"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deck"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Terminal presentations with style - animated backgrounds, hacker aesthetic, presenter mode"
 authors = ["Thijs Vos"]


### PR DESCRIPTION
Closes #25

Bump version to `0.2.0` and finalize `CHANGELOG.md` for release. Once merged, tag `v0.2.0` on `main` and push the tag — the `release.yml` workflow builds binaries for 4 targets and publishes a GitHub release.

## Summary
- `Cargo.toml`: `0.1.0` → `0.2.0`
- `Cargo.lock`: refresh `deck` entry
- `CHANGELOG.md`: promote `[Unreleased]` → `[0.2.0] - 2026-04-25`, add docs entry, open fresh `[Unreleased]`

## Test plan
- [x] `cargo build --release` — clean
- [x] `cargo test --bin deck` — 175/175 pass
- [x] After merge: `git tag -a v0.2.0 -m "Release 0.2.0" && git push origin v0.2.0`