### PR TITLE
Saturating arith, image sandbox, hot-path allocs, render split

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -393,7 +393,6 @@ impl App {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,19 +2,17 @@ use std::path::PathBuf;
 use std::time::Instant;
 
 use ratatui::{
-    layout::{Constraint, Direction, Layout as RLayout, Rect},
-    text::{Line, Span as RSpan},
-    widgets::{Block as WidgetBlock, Borders, Clear, Paragraph},
+    layout::{Constraint, Direction, Layout as RLayout},
     Frame,
 };
 
 use crate::background;
+use crate::bigtext::BigtextCache;
 use crate::entrance::EntranceTracker;
 use crate::highlight::Highlighter;
 use crate::image_renderer::{DeferredImage, ImageCache, ImageProtocol};
 use crate::input::{map_key, Action};
-use crate::markdown::Block;
-use crate::parse::{Deck, Slide};
+use crate::parse::Deck;
 use crate::render;
 use crate::render_presenter;
 use crate::sync::SyncFile;
@@ -81,6 +79,9 @@ pub struct App {
     pub base_dir: PathBuf,
     /// Cached syntect highlighter for fenced code blocks.
     pub highlighter: Highlighter,
+    /// Cached `bigtext::render` outputs so an unchanging H1 isn't re-rasterized
+    /// every frame.
+    pub bigtext_cache: BigtextCache,
     /// Per-block entrance animation tracker. Reset on slide change.
     pub entrances: EntranceTracker,
 }
@@ -100,7 +101,7 @@ impl App {
         base_dir: PathBuf,
     ) -> Self {
         assert!(!deck.slides.is_empty(), "deck must have at least one slide");
-        let reveal = initial_reveal(&deck.slides[0]);
+        let reveal = deck.slides[0].initial_reveal();
         let now = Instant::now();
         Self {
             deck,
@@ -121,6 +122,7 @@ impl App {
             deferred_images: Vec::new(),
             base_dir,
             highlighter: Highlighter::new(),
+            bigtext_cache: BigtextCache::new(),
             entrances: EntranceTracker::new(),
         }
     }
@@ -166,6 +168,7 @@ impl App {
             deferred: &mut self.deferred_images,
             base_dir: &self.base_dir,
             highlighter: &mut self.highlighter,
+            bigtext: &mut self.bigtext_cache,
             entrances: &mut self.entrances,
             slide_index: self.slide_index,
         };
@@ -213,20 +216,22 @@ impl App {
         render::render_status_bar(
             frame,
             status_area,
-            &self.deck.meta.title,
-            self.deck.meta.author.as_deref(),
-            self.slide_index + 1,
-            self.deck.slides.len(),
-            elapsed,
+            &render::StatusBar {
+                title: &self.deck.meta.title,
+                author: self.deck.meta.author.as_deref(),
+                slide_num: self.slide_index + 1,
+                total: self.deck.slides.len(),
+                elapsed_secs: elapsed,
+            },
             &self.theme,
         );
 
         // Overlays
         if self.show_help {
-            render_help(frame, area, &self.theme);
+            render::help_overlay(frame, area, &self.theme);
         }
         if self.in_goto {
-            render_goto(frame, area, &self.goto_input, &self.theme);
+            render::goto_overlay(frame, area, &self.goto_input, &self.theme);
         }
     }
 
@@ -338,24 +343,24 @@ impl App {
     }
 
     fn advance(&mut self) {
-        let total_bullets = count_bullets(&self.deck.slides[self.slide_index]);
+        let total_bullets = self.deck.slides[self.slide_index].bullet_count();
         if total_bullets > 0 && self.reveal_count < total_bullets {
             self.reveal_count += 1;
         } else if self.slide_index + 1 < self.deck.slides.len() {
             self.slide_index += 1;
-            self.reveal_count = initial_reveal(&self.deck.slides[self.slide_index]);
+            self.reveal_count = self.deck.slides[self.slide_index].initial_reveal();
             self.start_transition();
         }
         self.write_sync();
     }
 
     fn go_back(&mut self) {
-        let total_bullets = count_bullets(&self.deck.slides[self.slide_index]);
+        let total_bullets = self.deck.slides[self.slide_index].bullet_count();
         if total_bullets > 0 && self.reveal_count > 0 {
             self.reveal_count -= 1;
         } else if self.slide_index > 0 {
             self.slide_index -= 1;
-            let prev_bullets = count_bullets(&self.deck.slides[self.slide_index]);
+            let prev_bullets = self.deck.slides[self.slide_index].bullet_count();
             self.reveal_count = if prev_bullets > 0 {
                 prev_bullets
             } else {
@@ -370,7 +375,7 @@ impl App {
         let new_index = index.min(self.deck.slides.len().saturating_sub(1));
         if new_index != self.slide_index {
             self.slide_index = new_index;
-            self.reveal_count = initial_reveal(&self.deck.slides[self.slide_index]);
+            self.reveal_count = self.deck.slides[self.slide_index].initial_reveal();
             self.start_transition();
         }
         self.write_sync();
@@ -388,83 +393,6 @@ impl App {
     }
 }
 
-fn count_bullets(slide: &Slide) -> usize {
-    slide
-        .blocks
-        .iter()
-        .map(|b| match b {
-            Block::BulletList { items } => items.len(),
-            _ => 0,
-        })
-        .sum()
-}
-
-fn initial_reveal(slide: &Slide) -> usize {
-    let total = count_bullets(slide);
-    if total > 0 {
-        0
-    } else {
-        usize::MAX
-    }
-}
-
-fn render_help(frame: &mut Frame, area: Rect, theme: &Theme) {
-    let help_lines = [
-        "",
-        "  Navigation",
-        "  ─────────────────────────",
-        "  →/Space/Enter/l/j  Next",
-        "  ←/Backspace/h/k    Previous",
-        "  g                  First slide",
-        "  G                  Last slide",
-        "  :N Enter           Go to slide N",
-        "",
-        "  Controls",
-        "  ─────────────────────────",
-        "  p                  Presenter mode",
-        "  r                  Reset timer",
-        "  ?                  Toggle help",
-        "  q/Esc              Quit",
-        "",
-    ];
-
-    let width = 38u16;
-    let height = help_lines.len() as u16 + 2;
-    let x = area.width.saturating_sub(width) / 2;
-    let y = area.height.saturating_sub(height) / 2;
-    let rect = Rect::new(x, y, width, height);
-
-    frame.render_widget(Clear, rect);
-
-    let lines: Vec<Line> = help_lines
-        .iter()
-        .map(|s| Line::from(RSpan::styled(s.to_string(), theme.body_style())))
-        .collect();
-
-    let block = WidgetBlock::default()
-        .borders(Borders::ALL)
-        .border_style(theme.status_accent())
-        .title(" ? Help ");
-
-    frame.render_widget(Paragraph::new(lines).block(block), rect);
-}
-
-fn render_goto(frame: &mut Frame, area: Rect, input: &str, theme: &Theme) {
-    let width = 22u16;
-    let x = area.width.saturating_sub(width) / 2;
-    let y = area.height / 2;
-    let rect = Rect::new(x, y, width, 3);
-
-    frame.render_widget(Clear, rect);
-
-    let text = format!(":{input}_");
-    let block = WidgetBlock::default()
-        .borders(Borders::ALL)
-        .border_style(theme.status_accent())
-        .title(" Go to slide ");
-    let paragraph = Paragraph::new(RSpan::styled(text, theme.body_style())).block(block);
-    frame.render_widget(paragraph, rect);
-}
 
 #[cfg(test)]
 mod tests {
@@ -517,11 +445,11 @@ mod tests {
         KeyEvent::new(code, KeyModifiers::NONE)
     }
 
-    // T1-T3: count_bullets
+    // T1-T3: Slide::bullet_count
     #[test]
     fn count_bullets_empty_slide() {
         let slide = dummy_slide(vec![]);
-        assert_eq!(count_bullets(&slide), 0);
+        assert_eq!(slide.bullet_count(), 0);
     }
 
     #[test]
@@ -534,20 +462,20 @@ mod tests {
                 }],
             },
         ]);
-        assert_eq!(count_bullets(&slide), 3);
+        assert_eq!(slide.bullet_count(), 3);
     }
 
     #[test]
     fn count_bullets_sums_multiple_lists() {
         let slide = dummy_slide(vec![bullet_list(2), bullet_list(3)]);
-        assert_eq!(count_bullets(&slide), 5);
+        assert_eq!(slide.bullet_count(), 5);
     }
 
-    // T4-T5: initial_reveal
+    // T4-T5: Slide::initial_reveal
     #[test]
     fn initial_reveal_with_bullets_returns_zero() {
         let slide = dummy_slide(vec![bullet_list(3)]);
-        assert_eq!(initial_reveal(&slide), 0);
+        assert_eq!(slide.initial_reveal(), 0);
     }
 
     #[test]
@@ -556,7 +484,7 @@ mod tests {
             level: 1,
             text: "Hi".into(),
         }]);
-        assert_eq!(initial_reveal(&slide), usize::MAX);
+        assert_eq!(slide.initial_reveal(), usize::MAX);
     }
 
     // T6-T8: advance

--- a/src/background.rs
+++ b/src/background.rs
@@ -63,47 +63,38 @@ fn apply_percell(frame: &mut Frame, area: Rect, kind: &BackgroundKind, time: f64
 
     for y in 0..area.height {
         for x in 0..area.width {
-            let pos = (area.x + x, area.y + y);
-
-            if !is_empty(buf, pos) {
+            let pos = (area.x.saturating_add(x), area.y.saturating_add(y));
+            let Some(cell) = buf.cell_mut(pos) else {
+                continue;
+            };
+            let sym = cell.symbol();
+            if !sym.is_empty() && sym != " " {
                 continue;
             }
-
             let (ch, brightness) = compute_cell(kind, x, y, area.width, area.height, time);
-            write_bg_cell(buf, pos, ch, brightness, theme);
+            write_bg_cell(cell, ch, brightness, theme);
         }
     }
 }
 
 // ── helpers ────────────────────────────────────────────────────────
 
-fn is_empty(buf: &ratatui::buffer::Buffer, pos: (u16, u16)) -> bool {
-    buf.cell(pos)
-        .map(|c| {
-            let s = c.symbol();
-            s == " " || s.is_empty()
-        })
-        .unwrap_or(false)
-}
-
+/// Mutates `cell` to draw a background glyph at the given brightness. Skipping
+/// the empty-cell check is intentional — callers gate on `cell.symbol()` so
+/// they only call this for cells that should be painted.
 fn write_bg_cell(
-    buf: &mut ratatui::buffer::Buffer,
-    pos: (u16, u16),
+    cell: &mut ratatui::buffer::Cell,
     ch: char,
     brightness: f64,
     theme: &Theme,
 ) {
     if brightness < 0.02 {
-        if let Some(cell) = buf.cell_mut(pos) {
-            cell.set_char(' ');
-            cell.set_style(Style::default().bg(theme.bg));
-        }
+        cell.set_char(' ');
+        cell.set_style(Style::default().bg(theme.bg));
     } else {
         let fg = shade_color(theme, brightness);
-        if let Some(cell) = buf.cell_mut(pos) {
-            cell.set_char(ch);
-            cell.set_style(Style::default().fg(fg).bg(theme.bg));
-        }
+        cell.set_char(ch);
+        cell.set_style(Style::default().fg(fg).bg(theme.bg));
     }
 }
 
@@ -282,11 +273,14 @@ fn apply_lissajous_inner(
     let buf = frame.buffer_mut();
     for y in 0..area.height {
         for x in 0..area.width {
-            let pos = (area.x + x, area.y + y);
-            if !is_empty(buf, pos) {
+            let pos = (area.x.saturating_add(x), area.y.saturating_add(y));
+            let Some(cell) = buf.cell_mut(pos) else {
+                continue;
+            };
+            let sym = cell.symbol();
+            if !sym.is_empty() && sym != " " {
                 continue;
             }
-
             let brightness = grid[y as usize * w + x as usize];
             let ch = if brightness > 0.75 {
                 '█'
@@ -301,7 +295,7 @@ fn apply_lissajous_inner(
             } else {
                 ' '
             };
-            write_bg_cell(buf, pos, ch, brightness, theme);
+            write_bg_cell(cell, ch, brightness, theme);
         }
     }
 }
@@ -582,8 +576,12 @@ fn apply_orbit_inner(
     let buf = frame.buffer_mut();
     for y in 0..area.height {
         for x in 0..area.width {
-            let pos = (area.x + x, area.y + y);
-            if !is_empty(buf, pos) {
+            let pos = (area.x.saturating_add(x), area.y.saturating_add(y));
+            let Some(cell) = buf.cell_mut(pos) else {
+                continue;
+            };
+            let sym = cell.symbol();
+            if !sym.is_empty() && sym != " " {
                 continue;
             }
             let brightness = grid[y as usize * w + x as usize];
@@ -596,7 +594,7 @@ fn apply_orbit_inner(
             } else {
                 ' '
             };
-            write_bg_cell(buf, pos, ch, brightness, theme);
+            write_bg_cell(cell, ch, brightness, theme);
         }
     }
 }

--- a/src/background.rs
+++ b/src/background.rs
@@ -82,12 +82,7 @@ fn apply_percell(frame: &mut Frame, area: Rect, kind: &BackgroundKind, time: f64
 /// Mutates `cell` to draw a background glyph at the given brightness. Skipping
 /// the empty-cell check is intentional — callers gate on `cell.symbol()` so
 /// they only call this for cells that should be painted.
-fn write_bg_cell(
-    cell: &mut ratatui::buffer::Cell,
-    ch: char,
-    brightness: f64,
-    theme: &Theme,
-) {
+fn write_bg_cell(cell: &mut ratatui::buffer::Cell, ch: char, brightness: f64, theme: &Theme) {
     if brightness < 0.02 {
         cell.set_char(' ');
         cell.set_style(Style::default().bg(theme.bg));

--- a/src/bigtext.rs
+++ b/src/bigtext.rs
@@ -1,11 +1,50 @@
 /// Font style for H1 big text.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum FontStyle {
     /// Heavy block characters (█), 5 rows — hacker/catppuccin
     #[default]
     Block,
     /// Large clean block characters, 7 rows — corporate/minimal
     Large,
+}
+
+/// Cache for `render` results so an unchanging H1 isn't re-rasterized every frame.
+///
+/// Keyed by an `fnv1a(text) ^ font_bits` hash so cache lookups don't allocate
+/// on the hot path. Hash collisions just trigger a recompute, which matches the
+/// policy in `Highlighter` (see `util::fnv1a`).
+pub struct BigtextCache {
+    entries: std::collections::HashMap<u64, Vec<String>>,
+}
+
+impl BigtextCache {
+    pub fn new() -> Self {
+        Self {
+            entries: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Returns the rendered rows for `(text, font)`, computing and caching on miss.
+    pub fn render(&mut self, text: &str, font: FontStyle) -> &[String] {
+        let key = cache_key(text, font);
+        self.entries
+            .entry(key)
+            .or_insert_with(|| render(text, font))
+    }
+}
+
+impl Default for BigtextCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn cache_key(text: &str, font: FontStyle) -> u64 {
+    let font_bits: u64 = match font {
+        FontStyle::Block => 0,
+        FontStyle::Large => 1,
+    };
+    crate::util::fnv1a(text) ^ font_bits.wrapping_mul(0x9E3779B97F4A7C15)
 }
 
 pub fn glyph_block(c: char) -> Option<[&'static str; 5]> {

--- a/src/entrance.rs
+++ b/src/entrance.rs
@@ -50,9 +50,15 @@ impl EntranceState {
 }
 
 /// Tracks per-block entrance animations across frames.
-/// Keyed by (slide_index, block_index).
+///
+/// Keyed by `(slide_index, block_index, sub_index)`. `sub_index` is `0` for
+/// block-level animations (one entrance per block) and `1..=N` for cascade
+/// items (one per bullet inside a `BulletList`). The `sub != 0` carve-out
+/// keeps the cascade-item key space disjoint from the block-level key,
+/// removing the need for the previous `block_idx * 10_000 + item_i`
+/// magic-number encoding.
 pub struct EntranceTracker {
-    states: HashMap<(usize, usize), EntranceState>,
+    states: HashMap<(usize, usize, usize), EntranceState>,
     current_slide: usize,
 }
 
@@ -88,17 +94,20 @@ impl EntranceTracker {
     /// Returns `None` if the animation is already finished (no need to apply
     /// effects).
     ///
-    /// `kind` and `duration` are only used when creating a new state; on
-    /// subsequent calls for the same `(slide, block_idx)` they are ignored
-    /// and the existing state is returned.
+    /// `sub_idx` is `0` for the block's own entrance and `1..=N` for cascade
+    /// items inside the block (e.g. one per bullet). `kind` and `duration`
+    /// are only used when creating a new state; on subsequent calls for the
+    /// same `(slide, block_idx, sub_idx)` they are ignored and the existing
+    /// state is returned.
     pub fn get_or_start(
         &mut self,
         slide: usize,
         block_idx: usize,
+        sub_idx: usize,
         kind: EntranceKind,
         duration: Duration,
     ) -> Option<&EntranceState> {
-        let key = (slide, block_idx);
+        let key = (slide, block_idx, sub_idx);
         let state = self
             .states
             .entry(key)
@@ -214,7 +223,8 @@ mod tests {
     fn tracker_starts_new_animation() {
         let mut tracker = EntranceTracker::new();
         tracker.on_slide_change(0);
-        let state = tracker.get_or_start(0, 0, EntranceKind::Decrypt, Duration::from_millis(600));
+        let state =
+            tracker.get_or_start(0, 0, 0, EntranceKind::Decrypt, Duration::from_millis(600));
         assert!(state.is_some());
     }
 
@@ -222,7 +232,7 @@ mod tests {
     fn tracker_clears_on_slide_change() {
         let mut tracker = EntranceTracker::new();
         tracker.on_slide_change(0);
-        tracker.get_or_start(0, 0, EntranceKind::Decrypt, Duration::from_millis(600));
+        tracker.get_or_start(0, 0, 0, EntranceKind::Decrypt, Duration::from_millis(600));
         assert!(tracker.has_active());
         tracker.on_slide_change(1);
         assert!(!tracker.has_active());
@@ -234,10 +244,11 @@ mod tests {
         tracker.on_slide_change(0);
         // Insert a state that's already done
         tracker.states.insert(
-            (0, 0),
+            (0, 0, 0),
             EntranceState::new(EntranceKind::FadeIn, Duration::ZERO),
         );
-        let state = tracker.get_or_start(0, 0, EntranceKind::FadeIn, Duration::from_millis(200));
+        let state =
+            tracker.get_or_start(0, 0, 0, EntranceKind::FadeIn, Duration::from_millis(200));
         assert!(state.is_none()); // already finished
     }
 
@@ -284,7 +295,7 @@ mod tests {
     fn tracker_has_active_with_running() {
         let mut tracker = EntranceTracker::new();
         tracker.on_slide_change(0);
-        tracker.get_or_start(0, 0, EntranceKind::Decrypt, Duration::from_secs(10));
+        tracker.get_or_start(0, 0, 0, EntranceKind::Decrypt, Duration::from_secs(10));
         assert!(tracker.has_active());
     }
 }

--- a/src/entrance.rs
+++ b/src/entrance.rs
@@ -247,8 +247,7 @@ mod tests {
             (0, 0, 0),
             EntranceState::new(EntranceKind::FadeIn, Duration::ZERO),
         );
-        let state =
-            tracker.get_or_start(0, 0, 0, EntranceKind::FadeIn, Duration::from_millis(200));
+        let state = tracker.get_or_start(0, 0, 0, EntranceKind::FadeIn, Duration::from_millis(200));
         assert!(state.is_none()); // already finished
     }
 

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -6,14 +6,18 @@ use ratatui::text::{Line, Span};
 use syntect::highlighting::{FontStyle, Theme as SynTheme, ThemeSet};
 use syntect::parsing::SyntaxSet;
 
+use crate::util::fnv1a;
+
 /// Syntax highlighter backed by syntect. Caches results per (code, lang) pair.
 ///
 /// Cache values are wrapped in `Arc` so cache hits are a refcount bump
-/// rather than a deep clone of every line and span.
+/// rather than a deep clone of every line and span. The cache is keyed by an
+/// `fnv1a` hash so cache lookups don't allocate a `String` per frame; on the
+/// rare hash collision the worst case is a redundant re-highlight.
 pub struct Highlighter {
     syntax_set: SyntaxSet,
     theme: SynTheme,
-    cache: HashMap<(String, String), Arc<Vec<Line<'static>>>>,
+    cache: HashMap<u64, Arc<Vec<Line<'static>>>>,
 }
 
 impl Highlighter {
@@ -42,7 +46,7 @@ impl Highlighter {
     /// Results are cached per `(code, lang)`. Returns an `Arc` so repeated
     /// calls (typewriter animation, multiple frames) are cheap refcount bumps.
     pub fn highlight(&mut self, code: &str, lang: &str) -> Arc<Vec<Line<'static>>> {
-        let key = (code.to_string(), lang.to_string());
+        let key = fnv1a(code) ^ fnv1a(lang).wrapping_mul(0x9E3779B97F4A7C15);
         if let Some(cached) = self.cache.get(&key) {
             return Arc::clone(cached);
         }

--- a/src/image_renderer.rs
+++ b/src/image_renderer.rs
@@ -67,6 +67,19 @@ impl<K: std::hash::Hash + Eq + Clone, V> FifoCache<K, V> {
     }
 }
 
+impl<V> FifoCache<String, V> {
+    /// Borrowed-key lookup for `String`-keyed caches. Avoids the per-call
+    /// `to_string()` that callers would otherwise need to construct an owned
+    /// key for `HashMap::contains_key`.
+    fn contains_key_str(&self, k: &str) -> bool {
+        self.map.contains_key(k)
+    }
+
+    fn get_str(&self, k: &str) -> Option<&V> {
+        self.map.get(k)
+    }
+}
+
 /// Cache key keyed by the raw `src` string. Avoids canonicalizing the path
 /// on every frame's lookup; canonicalize only runs on cache miss to validate
 /// the path.
@@ -77,20 +90,16 @@ type ResizedKey = (String, u16, u16);
 /// - `originals`: decoded RGBA images keyed by raw `src`
 /// - `resized`: resized images keyed by `(src, cols, rows)`
 /// - `encoded`: pre-encoded Kitty base64 PNG keyed by `(src, cols, rows)`
-/// - `validated`: set of `src` strings that have already passed the
-///   path-traversal check
 ///
 /// Each tier is FIFO-evicted independently. Decode + resize + encode each
-/// happen at most once per unique key.
+/// happen at most once per unique key. Sandbox validation (`resolve_and_validate`)
+/// runs on every cache miss; there is no per-`src` validation cache because the
+/// canonicalize syscall is cheap relative to image decode and a stale validation
+/// cache would silently keep accepting paths after `base_dir` moved.
 pub struct ImageCache {
     originals: FifoCache<String, Arc<RgbaImage>>,
     resized: FifoCache<ResizedKey, Arc<RgbaImage>>,
     encoded: FifoCache<ResizedKey, String>,
-    /// `src` strings that have already passed the path-traversal check.
-    /// Avoids re-running the `base_dir.canonicalize()` + `starts_with` check
-    /// on every cache hit. The `src` itself is still re-canonicalized via
-    /// `resolve()` on hit to recover the resolved path.
-    validated: HashMap<String, ()>,
 }
 
 const DEFAULT_MAX_RESIZED: usize = 64;
@@ -105,32 +114,38 @@ impl ImageCache {
             originals: FifoCache::new(DEFAULT_MAX_ORIGINALS),
             resized: FifoCache::new(DEFAULT_MAX_RESIZED),
             encoded: FifoCache::new(DEFAULT_MAX_ENCODED),
-            validated: HashMap::new(),
         }
     }
 
-    /// Resolve and validate `src`. Absolute paths are trusted (the user
-    /// explicitly typed them) and bypass the sandbox check; relative paths
-    /// are sandboxed to `base_dir`. Returns the canonicalized path on success.
+    /// Resolve and sandbox-check `src`. Returns the canonicalized path on success.
     ///
-    /// The first call for a given `src` runs the full sandbox check; later
-    /// calls for the same `src` short-circuit via the `validated` set and
-    /// re-resolve the path only. The `validated` set is never invalidated,
-    /// so renaming or moving `base_dir` after first validation is not
-    /// detected.
-    fn resolve_and_validate(&mut self, src: &str, base_dir: &Path) -> Option<PathBuf> {
-        if self.validated.contains_key(src) {
-            return resolve(src, base_dir);
-        }
+    /// The check applies to both relative and absolute paths from the markdown:
+    /// the resolved path must live under `base_dir`, even when the markdown writes
+    /// an absolute `src`. Symlinks under `base_dir` are refused outright — without
+    /// this, a symlink at e.g. `./innocent.png -> /home/user/.ssh/id_rsa` would
+    /// `canonicalize()` to a target outside `base_dir` and fall through to a
+    /// decode error that still leaks file existence via timing.
+    fn resolve_and_validate(&self, src: &str, base_dir: &Path) -> Option<PathBuf> {
         let resolved = resolve(src, base_dir)?;
-        let is_absolute = Path::new(src).is_absolute();
-        if !is_absolute {
-            let base = base_dir.canonicalize().ok()?;
-            if !resolved.starts_with(&base) {
-                return None;
-            }
+        let base = base_dir.canonicalize().ok()?;
+        if !resolved.starts_with(&base) {
+            return None;
         }
-        self.validated.insert(src.to_string(), ());
+        // Refuse symlinks (resolved is already canonicalized, but the original
+        // src may have been a symlink whose canonical target happens to land
+        // inside base_dir; symlink_metadata sees the link itself).
+        let original = if Path::new(src).is_absolute() {
+            PathBuf::from(src)
+        } else {
+            base_dir.join(src)
+        };
+        if std::fs::symlink_metadata(&original)
+            .ok()?
+            .file_type()
+            .is_symlink()
+        {
+            return None;
+        }
         Some(resolved)
     }
 
@@ -155,12 +170,12 @@ impl ImageCache {
         // Cache miss: validate path, decode if needed, resize.
         let resolved = self.resolve_and_validate(src, base_dir)?;
 
-        if !self.originals.contains(&src.to_string()) {
+        if !self.originals.contains_key_str(src) {
             let img = decode_with_limits(&resolved)?;
             self.originals.insert(src.to_string(), Arc::new(img));
         }
 
-        let original = self.originals.get(&src.to_string())?.clone();
+        let original = self.originals.get_str(src)?.clone();
         let resized = resize_to_fit(&original, max_cols, max_rows);
         self.resized.insert(key.clone(), Arc::new(resized));
         self.resized.get(&key)
@@ -367,13 +382,14 @@ fn render_kitty<W: Write>(w: &mut W, d: &DeferredImage) -> std::io::Result<()> {
 
     // Send chunked if >4096 bytes
     let chunk_size = 4096;
-    let chunks: Vec<&[u8]> = b64.as_bytes().chunks(chunk_size).collect();
+    let bytes = b64.as_bytes();
+    let total_chunks = bytes.len().div_ceil(chunk_size).max(1);
 
-    if chunks.len() <= 1 {
+    if total_chunks <= 1 {
         write!(w, "\x1b_Ga=T,f=100,c={},r={};{}\x1b\\", d.cols, d.rows, b64)?;
     } else {
-        for (i, chunk) in chunks.iter().enumerate() {
-            let is_last = i == chunks.len() - 1;
+        for (i, chunk) in bytes.chunks(chunk_size).enumerate() {
+            let is_last = i + 1 == total_chunks;
             let m = if is_last { 0 } else { 1 };
             let chunk_str =
                 std::str::from_utf8(chunk).expect("base64 output is always valid ASCII/UTF-8");

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,18 @@ mod theme;
 mod transition;
 mod util;
 
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::path::Path;
 use std::time::Duration;
+
+/// Maximum bytes read from the markdown deck file. 16 MB is generous for any
+/// realistic presentation and caps the worst case (huge symlink, accidental
+/// binary).
+const MAX_DECK_BYTES: u64 = 16 * 1024 * 1024;
+
+const ANIMATION_TICK: Duration = Duration::from_millis(16); // 60 FPS for transitions/entrances
+const BACKGROUND_TICK: Duration = Duration::from_millis(33); // ~30 FPS for animated backgrounds and sync polling
+const IDLE_TICK: Duration = Duration::from_millis(100); // low CPU when nothing is moving
 
 use clap::Parser;
 use crossterm::{
@@ -54,8 +63,11 @@ struct Cli {
 fn main() -> io::Result<()> {
     let cli = Cli::parse();
 
-    let content = std::fs::read_to_string(&cli.file)
-        .map_err(|e| io::Error::new(io::ErrorKind::NotFound, format!("{}: {}", cli.file, e)))?;
+    let mut content = String::new();
+    std::fs::File::open(&cli.file)
+        .map_err(|e| io::Error::new(io::ErrorKind::NotFound, format!("{}: {}", cli.file, e)))?
+        .take(MAX_DECK_BYTES)
+        .read_to_string(&mut content)?;
 
     let deck = parse_deck(&content);
 
@@ -110,11 +122,11 @@ fn main() -> io::Result<()> {
         }
 
         let timeout = if app.transition.is_some() || app.entrances.has_active() {
-            Duration::from_millis(16) // 60fps during transitions/entrances
+            ANIMATION_TICK
         } else if app.has_active_background() || app.is_follower {
-            Duration::from_millis(33) // ~30fps for backgrounds or sync polling
+            BACKGROUND_TICK
         } else {
-            Duration::from_millis(100) // low CPU when idle
+            IDLE_TICK
         };
 
         if event::poll(timeout)? {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -63,6 +63,32 @@ pub struct Slide {
     pub background: Option<BackgroundKind>,
 }
 
+impl Slide {
+    /// Total bullets across all top-level `BulletList` blocks. Numbered lists
+    /// and bullets nested inside other blocks (e.g. columns) are excluded —
+    /// only the top-level reveal cursor consumes these.
+    pub fn bullet_count(&self) -> usize {
+        self.blocks
+            .iter()
+            .map(|b| match b {
+                Block::BulletList { items } => items.len(),
+                _ => 0,
+            })
+            .sum()
+    }
+
+    /// Initial value of `App::reveal_count` for this slide: `0` when there are
+    /// bullets to progressively reveal, `usize::MAX` otherwise so `advance`
+    /// moves straight to the next slide.
+    pub fn initial_reveal(&self) -> usize {
+        if self.bullet_count() > 0 {
+            0
+        } else {
+            usize::MAX
+        }
+    }
+}
+
 /// Two-column slide body: left and right block sequences rendered side-by-side.
 #[derive(Debug)]
 pub struct Columns {
@@ -126,9 +152,24 @@ fn extract_frontmatter(input: &str) -> (DeckMeta, String) {
     };
     let after_first = after_first.trim_start_matches(['\n', '\r']);
 
-    if let Some(end) = after_first.find("\n---") {
+    // Match end-of-frontmatter only when `---` is line-anchored: followed by
+    // EOF, `\n`, or `\r\n`. Avoids prematurely terminating on a TOML triple-
+    // quoted string that happens to contain `\n---`.
+    let mut search_from = 0;
+    let end = loop {
+        let Some(pos) = after_first[search_from..].find("\n---") else {
+            break None;
+        };
+        let abs = search_from + pos;
+        let after = &after_first[abs + 4..];
+        if after.is_empty() || after.starts_with('\n') || after.starts_with("\r\n") {
+            break Some(abs);
+        }
+        search_from = abs + 4;
+    };
+    if let Some(end) = end {
         let frontmatter_str = &after_first[..end];
-        let rest = &after_first[end + 4..];
+        let rest = after_first.get(end + 4..).unwrap_or("");
 
         if let Ok(meta) = toml::from_str::<DeckMeta>(frontmatter_str) {
             return (meta, rest.to_string());

--- a/src/render.rs
+++ b/src/render.rs
@@ -385,7 +385,9 @@ fn render_block(
         Block::Paragraph { spans } => render_paragraph(frame, area, spans, theme),
         Block::BulletList { items } => render_bullet_list_static(frame, area, items, theme),
         Block::NumberedList { items } => render_numbered_list(frame, area, items, theme),
-        Block::Code { lang, code } => render_code(frame, area, lang.as_deref(), code, theme, ctx, block_idx),
+        Block::Code { lang, code } => {
+            render_code(frame, area, lang.as_deref(), code, theme, ctx, block_idx)
+        }
         Block::HorizontalRule => render_horizontal_rule(frame, area, theme),
         Block::Image { path, alt } => render_image(frame, area, path, alt, theme, ctx),
     }
@@ -442,13 +444,7 @@ fn render_bullet_list_static<'a>(
 ) -> BlockRender {
     let mut h = 0u16;
     for item in items {
-        let lh = render_bullet_item(
-            frame,
-            area,
-            area.y.saturating_add(h),
-            &item.spans,
-            theme,
-        );
+        let lh = render_bullet_item(frame, area, area.y.saturating_add(h), &item.spans, theme);
         h = h.saturating_add(lh);
     }
     BlockRender::self_entrance(h) // bullets handle their own entrances
@@ -523,7 +519,11 @@ fn render_code(
                     let total_chars: usize =
                         hl.spans.iter().map(|s| s.content.chars().count()).sum();
                     let chars_to_show = (char_frac * total_chars as f64) as usize;
-                    out.push(typewriter_partial_line(&hl.spans, chars_to_show, cursor_style));
+                    out.push(typewriter_partial_line(
+                        &hl.spans,
+                        chars_to_show,
+                        cursor_style,
+                    ));
                 } else {
                     out.push(Line::from(""));
                 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -6,11 +6,11 @@ use ratatui::{
     layout::{Constraint, Direction, Layout as RLayout, Rect},
     style::Style,
     text::{Line, Span as RSpan},
-    widgets::{Block as WidgetBlock, Borders, Paragraph, Wrap},
+    widgets::{Block as WidgetBlock, Borders, Clear, Paragraph, Wrap},
     Frame,
 };
 
-use crate::bigtext;
+use crate::bigtext::BigtextCache;
 use crate::entrance::{self, EntranceKind, EntranceTracker};
 use crate::highlight::Highlighter;
 use crate::image_renderer::{self, DeferredImage, ImageCache, ImageProtocol};
@@ -20,14 +20,16 @@ use crate::theme::Theme;
 
 /// Shared per-frame rendering context bundling all state the slide renderer
 /// reads or mutates: image protocol + cache, deferred-render queue, sandbox
-/// base dir, syntax highlighter, entrance-animation tracker, and the index of
-/// the slide currently being drawn (used as the entrance-tracker key).
+/// base dir, syntax highlighter, big-text cache, entrance-animation tracker,
+/// and the index of the slide currently being drawn (used as the
+/// entrance-tracker key).
 pub struct RenderCtx<'a> {
     pub protocol: ImageProtocol,
     pub image_cache: &'a mut ImageCache,
     pub deferred: &'a mut Vec<DeferredImage>,
     pub base_dir: &'a Path,
     pub highlighter: &'a mut Highlighter,
+    pub bigtext: &'a mut BigtextCache,
     pub entrances: &'a mut EntranceTracker,
     pub slide_index: usize,
 }
@@ -72,18 +74,20 @@ pub fn render_slide(
                     content.x,
                     y,
                     content.width,
-                    content.height.saturating_sub(y - content.y),
+                    content.height.saturating_sub(y.saturating_sub(content.y)),
                 );
-                let (h, _) = render_block(frame, remaining, block, theme, ctx, i);
-                y += h;
+                let result = render_block(frame, remaining, block, theme, ctx, i);
+                y = y.saturating_add(result.height);
             }
 
             if let Some(cols) = &slide.columns {
                 let col_area = Rect::new(
                     content.x,
-                    y + 1,
+                    y.saturating_add(1),
                     content.width,
-                    content.height.saturating_sub(y - content.y + 1),
+                    content
+                        .height
+                        .saturating_sub(y.saturating_sub(content.y).saturating_add(1)),
                 );
                 let halves = RLayout::default()
                     .direction(Direction::Horizontal)
@@ -98,30 +102,30 @@ pub fn render_slide(
     }
 }
 
+/// Snapshot of state the status bar needs to render. Pass to
+/// [`render_status_bar`] to avoid an 8-argument call site.
+pub struct StatusBar<'a> {
+    pub title: &'a str,
+    pub author: Option<&'a str>,
+    pub slide_num: usize,
+    pub total: usize,
+    pub elapsed_secs: u64,
+}
+
 /// Draw the bottom status bar.
 ///
 /// Layout: deck title (and optional author) on the left, slide counter
 /// centered, elapsed `mm:ss` timer on the right. Padding between segments is
 /// filled with `─` glyphs.
-#[allow(clippy::too_many_arguments)]
-pub fn render_status_bar(
-    frame: &mut Frame,
-    area: Rect,
-    title: &str,
-    author: Option<&str>,
-    slide_num: usize,
-    total: usize,
-    elapsed_secs: u64,
-    theme: &Theme,
-) {
-    let mins = elapsed_secs / 60;
-    let secs = elapsed_secs % 60;
+pub fn render_status_bar(frame: &mut Frame, area: Rect, info: &StatusBar, theme: &Theme) {
+    let mins = info.elapsed_secs / 60;
+    let secs = info.elapsed_secs % 60;
 
-    let left = match author {
-        Some(a) if !a.is_empty() => format!(" {title} — {a} "),
-        _ => format!(" {title} "),
+    let left = match info.author {
+        Some(a) if !a.is_empty() => format!(" {} — {} ", info.title, a),
+        _ => format!(" {} ", info.title),
     };
-    let center = format!(" {slide_num}/{total} ");
+    let center = format!(" {}/{} ", info.slide_num, info.total);
     let right = format!(" {mins:02}:{secs:02} ");
 
     let width = area.width as usize;
@@ -143,6 +147,66 @@ pub fn render_status_bar(
     frame.render_widget(Paragraph::new(line), area);
 }
 
+/// Help overlay shown when `?` is pressed.
+pub fn help_overlay(frame: &mut Frame, area: Rect, theme: &Theme) {
+    let help_lines = [
+        "",
+        "  Navigation",
+        "  ─────────────────────────",
+        "  →/Space/Enter/l/j  Next",
+        "  ←/Backspace/h/k    Previous",
+        "  g                  First slide",
+        "  G                  Last slide",
+        "  :N Enter           Go to slide N",
+        "",
+        "  Controls",
+        "  ─────────────────────────",
+        "  p                  Presenter mode",
+        "  r                  Reset timer",
+        "  ?                  Toggle help",
+        "  q/Esc              Quit",
+        "",
+    ];
+
+    let width = 38u16;
+    let height = help_lines.len() as u16 + 2;
+    let x = area.width.saturating_sub(width) / 2;
+    let y = area.height.saturating_sub(height) / 2;
+    let rect = Rect::new(x, y, width, height);
+
+    frame.render_widget(Clear, rect);
+
+    let lines: Vec<Line> = help_lines
+        .iter()
+        .map(|s| Line::from(RSpan::styled(*s, theme.body_style())))
+        .collect();
+
+    let block = WidgetBlock::default()
+        .borders(Borders::ALL)
+        .border_style(theme.status_accent())
+        .title(" ? Help ");
+
+    frame.render_widget(Paragraph::new(lines).block(block), rect);
+}
+
+/// `:N Enter` go-to overlay accepting a slide-number buffer.
+pub fn goto_overlay(frame: &mut Frame, area: Rect, input: &str, theme: &Theme) {
+    let width = 22u16;
+    let x = area.width.saturating_sub(width) / 2;
+    let y = area.height / 2;
+    let rect = Rect::new(x, y, width, 3);
+
+    frame.render_widget(Clear, rect);
+
+    let text = format!(":{input}_");
+    let block = WidgetBlock::default()
+        .borders(Borders::ALL)
+        .border_style(theme.status_accent())
+        .title(" Go to slide ");
+    let paragraph = Paragraph::new(RSpan::styled(text, theme.body_style())).block(block);
+    frame.render_widget(paragraph, rect);
+}
+
 fn render_blocks(
     frame: &mut Frame,
     area: Rect,
@@ -155,7 +219,7 @@ fn render_blocks(
     let mut bullet_count: usize = 0;
 
     for (block_idx, block) in blocks.iter().enumerate() {
-        if y >= area.y + area.height {
+        if y >= area.y.saturating_add(area.height) {
             break;
         }
 
@@ -163,7 +227,7 @@ fn render_blocks(
             area.x,
             y,
             area.width,
-            area.height.saturating_sub(y - area.y),
+            area.height.saturating_sub(y.saturating_sub(area.y)),
         );
 
         match block {
@@ -172,33 +236,21 @@ fn render_blocks(
                     if bullet_count >= reveal {
                         return;
                     }
-                    let line = spans_to_line(&item.spans, theme);
-                    let mut spans_vec = vec![RSpan::styled(
-                        format!("  {} ", theme.bullet),
-                        theme.bullet_style(),
-                    )];
-                    spans_vec.extend(line.spans);
-                    let combined = Line::from(spans_vec);
-                    let h = estimate_line_height(&combined, remaining.width);
-                    if y + h > area.y + area.height {
+                    let h = render_bullet_item(frame, remaining, y, &item.spans, theme);
+                    if y.saturating_add(h) > area.y.saturating_add(area.height) {
                         return;
                     }
                     let bullet_rect = Rect::new(remaining.x, y, remaining.width, h);
-                    frame.render_widget(
-                        Paragraph::new(combined).wrap(Wrap { trim: false }),
-                        bullet_rect,
-                    );
 
                     // Cascade entrance: fixed 300ms animation per bullet, staggered start.
-                    // Encode (block_idx, item_i) into a single key. 10_000 leaves headroom for
-                    // bullet lists with up to 9_999 items per block — far beyond realistic decks.
-                    debug_assert!(item_i < 10_000, "bullet list exceeds cascade-idx capacity");
-                    let cascade_idx = block_idx * 10_000 + item_i;
+                    // sub_idx = item_i + 1 keeps each item disjoint from the block's own
+                    // sub_idx = 0 entrance slot.
                     let stagger = std::time::Duration::from_millis(80 * item_i as u64);
                     let anim_dur = std::time::Duration::from_millis(300);
                     if let Some(state) = ctx.entrances.get_or_start(
                         ctx.slide_index,
-                        cascade_idx,
+                        block_idx,
+                        item_i + 1,
                         EntranceKind::Cascade,
                         stagger + anim_dur,
                     ) {
@@ -210,22 +262,50 @@ fn render_blocks(
                         entrance::apply_fade_in(frame, bullet_rect, visual_progress, theme);
                     }
 
-                    y += h;
+                    y = y.saturating_add(h);
                     bullet_count += 1;
                 }
             }
             _ => {
-                let (h, block_rect) = render_block(frame, remaining, block, theme, ctx, block_idx);
+                let result = render_block(frame, remaining, block, theme, ctx, block_idx);
 
                 // Apply entrance effects based on block type
-                if let Some(block_rect) = block_rect {
-                    apply_entrance_for_block(frame, block, block_rect, theme, ctx, block_idx);
+                if let Some(rect) = result.entrance_target {
+                    apply_entrance_for_block(frame, block, rect, theme, ctx, block_idx);
                 }
 
-                y += h;
+                y = y.saturating_add(result.height);
             }
         }
     }
+}
+
+/// Render one bullet at `(area.x, y)` and return the height it consumed.
+///
+/// Used by both `render_blocks` (the cascade-entrance path) and the static
+/// `BulletList` arm of `render_block`. Borrows the bullet prefix from the
+/// theme to avoid `format!`-allocating per bullet per frame.
+fn render_bullet_item<'a>(
+    frame: &mut Frame,
+    area: Rect,
+    y: u16,
+    spans: &'a [Span],
+    theme: &'a Theme,
+) -> u16 {
+    let line = spans_to_line(spans, theme);
+    let mut spans_vec: Vec<RSpan<'a>> = Vec::with_capacity(line.spans.len() + 1);
+    spans_vec.push(RSpan::styled(
+        theme.bullet_prefix.as_str(),
+        theme.bullet_style(),
+    ));
+    spans_vec.extend(line.spans);
+    let combined = Line::from(spans_vec);
+    let h = estimate_line_height(&combined, area.width);
+    frame.render_widget(
+        Paragraph::new(combined).wrap(Wrap { trim: false }),
+        Rect::new(area.x, y, area.width, h),
+    );
+    h
 }
 
 fn apply_entrance_for_block(
@@ -249,7 +329,7 @@ fn apply_entrance_for_block(
 
     if let Some(state) = ctx
         .entrances
-        .get_or_start(ctx.slide_index, block_idx, kind, duration)
+        .get_or_start(ctx.slide_index, block_idx, 0, kind, duration)
     {
         let progress = state.progress();
         match &state.kind {
@@ -264,7 +344,33 @@ fn apply_entrance_for_block(
     }
 }
 
-/// Renders a single block and returns (consumed_height, block_rect).
+/// Result of rendering one block: how much vertical space was consumed and,
+/// if applicable, the rect to feed [`apply_entrance_for_block`] afterwards.
+struct BlockRender {
+    height: u16,
+    /// Rect for the post-render entrance pass. `None` means the block applied
+    /// its own entrance during render (typewriter for code, cascade for
+    /// bullets) — do not double-apply.
+    entrance_target: Option<Rect>,
+}
+
+impl BlockRender {
+    fn self_entrance(height: u16) -> Self {
+        Self {
+            height,
+            entrance_target: None,
+        }
+    }
+
+    fn with_entrance(height: u16, rect: Rect) -> Self {
+        Self {
+            height,
+            entrance_target: Some(rect),
+        }
+    }
+}
+
+/// Dispatches to a per-arm helper.
 fn render_block(
     frame: &mut Frame,
     area: Rect,
@@ -272,240 +378,319 @@ fn render_block(
     theme: &Theme,
     ctx: &mut RenderCtx,
     block_idx: usize,
-) -> (u16, Option<Rect>) {
+) -> BlockRender {
     match block {
-        Block::Heading { level: 1, text } => {
-            let big = bigtext::render(text, theme.font);
-            let height = big.len() as u16;
-            let rect = Rect::new(area.x, area.y, area.width, height.min(area.height));
-            for (i, line_str) in big.iter().enumerate() {
-                if area.y + i as u16 >= area.y + area.height {
-                    break;
-                }
-                let span = RSpan::styled(line_str.clone(), theme.h1_style());
-                frame.render_widget(
-                    Paragraph::new(Line::from(span)),
-                    Rect::new(area.x, area.y + i as u16, area.width, 1),
-                );
-            }
-            (height + 1, Some(rect))
-        }
-        Block::Heading { text, .. } => {
-            let rect = Rect::new(area.x, area.y, area.width, 1);
-            let line = Line::from(vec![RSpan::styled(text.clone(), theme.heading_style())]);
-            frame.render_widget(Paragraph::new(line), rect);
-            (2, Some(rect))
-        }
-        Block::Paragraph { spans } => {
-            let line = spans_to_line(spans, theme);
-            let h = estimate_line_height(&line, area.width);
-            let rect = Rect::new(area.x, area.y, area.width, h);
-            frame.render_widget(Paragraph::new(line).wrap(Wrap { trim: false }), rect);
-            (h + 1, Some(rect))
-        }
-        Block::BulletList { items } => {
-            let mut h = 0u16;
-            for item in items {
-                let line = spans_to_line(&item.spans, theme);
-                let mut spans_vec = vec![RSpan::styled(
-                    format!("  {} ", theme.bullet),
-                    theme.bullet_style(),
-                )];
-                spans_vec.extend(line.spans);
-                let combined = Line::from(spans_vec);
-                let lh = estimate_line_height(&combined, area.width);
-                frame.render_widget(
-                    Paragraph::new(combined).wrap(Wrap { trim: false }),
-                    Rect::new(area.x, area.y + h, area.width, lh),
-                );
-                h += lh;
-            }
-            (h, None) // bullets handle their own entrances
-        }
-        Block::NumberedList { items } => {
-            let mut h = 0u16;
-            for (i, item) in items.iter().enumerate() {
-                let line = spans_to_line(&item.spans, theme);
-                let mut spans_vec = vec![RSpan::styled(
-                    format!("  {}. ", i + 1),
-                    theme.bullet_style(),
-                )];
-                spans_vec.extend(line.spans);
-                let combined = Line::from(spans_vec);
-                let lh = estimate_line_height(&combined, area.width);
-                frame.render_widget(
-                    Paragraph::new(combined).wrap(Wrap { trim: false }),
-                    Rect::new(area.x, area.y + h, area.width, lh),
-                );
-                h += lh;
-            }
-            (h, None)
-        }
-        Block::Code { lang, code } => {
-            let title = lang.as_deref().unwrap_or("");
-            let highlighted = ctx
-                .highlighter
-                .highlight(code, if title.is_empty() { "txt" } else { title });
-            let total_lines = highlighted.len();
-            let inner_height = total_lines.max(1) as u16;
-            let total_height = inner_height + 2; // borders
-
-            // Check for typewriter entrance
-            let typewriter_dur = std::time::Duration::from_millis(50 * total_lines as u64 + 200);
-            let entrance = ctx.entrances.get_or_start(
-                ctx.slide_index,
-                block_idx,
-                EntranceKind::Typewriter,
-                typewriter_dur,
-            );
-
-            let (visible_lines, char_frac) = match entrance {
-                Some(state) => entrance::typewriter_visible(state.progress(), total_lines),
-                None => (total_lines, 1.0),
-            };
-
-            // Build visible lines with optional partial last line + cursor.
-            // `highlighted` is an Arc — iterate by reference and clone only what we use.
-            let mut lines: Vec<Line<'static>> = Vec::with_capacity(inner_height as usize);
-            for (i, hl) in highlighted.iter().enumerate() {
-                if i < visible_lines {
-                    lines.push(hl.clone());
-                } else if i == visible_lines && visible_lines < total_lines {
-                    // Partially typed current line
-                    let full_text: String = hl.spans.iter().map(|s| s.content.as_ref()).collect();
-                    let chars_to_show = (char_frac * full_text.chars().count() as f64) as usize;
-                    if chars_to_show == 0 {
-                        // Just show cursor
-                        lines.push(Line::from(RSpan::styled("▌", theme.status_accent())));
-                    } else {
-                        // Truncate spans to chars_to_show characters
-                        let mut partial_spans: Vec<RSpan<'static>> = Vec::new();
-                        let mut chars_left = chars_to_show;
-                        for span in &hl.spans {
-                            let span_len = span.content.chars().count();
-                            if chars_left >= span_len {
-                                partial_spans.push(span.clone());
-                                chars_left -= span_len;
-                            } else {
-                                let truncated: String =
-                                    span.content.chars().take(chars_left).collect();
-                                partial_spans.push(RSpan::styled(truncated, span.style));
-                                break;
-                            }
-                        }
-                        // Append blinking cursor
-                        partial_spans.push(RSpan::styled("▌", theme.status_accent()));
-                        lines.push(Line::from(partial_spans));
-                    }
-                } else {
-                    // Not yet visible — empty line to maintain block height
-                    lines.push(Line::from(""));
-                }
-            }
-
-            let code_bg = ctx.highlighter.bg_color().unwrap_or(theme.code_bg);
-            let block_widget = WidgetBlock::default()
-                .borders(Borders::ALL)
-                .border_style(theme.code_border())
-                .title(title);
-            let paragraph = Paragraph::new(lines)
-                .style(Style::default().bg(code_bg))
-                .block(block_widget);
-            let code_rect = Rect::new(area.x, area.y, area.width, total_height.min(area.height));
-            frame.render_widget(paragraph, code_rect);
-            (total_height + 1, None) // code handles its own entrance via typewriter
-        }
-        Block::HorizontalRule => {
-            let rule = "─".repeat(area.width as usize);
-            frame.render_widget(
-                Paragraph::new(RSpan::styled(rule, theme.rule_style())),
-                Rect::new(area.x, area.y, area.width, 1),
-            );
-            (2, None)
-        }
-        Block::Image { path, alt } => {
-            // Load, resize, and cache — only resizes once per (path, size)
-            let resized =
-                match ctx
-                    .image_cache
-                    .get_resized(path, ctx.base_dir, area.width, area.height)
-                {
-                    Some(img) => img.clone(),
-                    None => {
-                        let label = if alt.is_empty() {
-                            format!("[Image: {path}]")
-                        } else {
-                            format!("[Image: {alt}]")
-                        };
-                        let line = Line::from(RSpan::styled(label, theme.rule_style()));
-                        frame.render_widget(
-                            Paragraph::new(line),
-                            Rect::new(area.x, area.y, area.width, 1),
-                        );
-                        return (2, None);
-                    }
-                };
-
-            let (px_w, px_h) = resized.dimensions();
-            let consumed_rows = px_h.div_ceil(2) as u16;
-            let consumed_cols = px_w as u16;
-
-            // Center horizontally
-            let x_offset = area.width.saturating_sub(consumed_cols) / 2;
-            let img_area = Rect::new(
-                area.x + x_offset,
-                area.y,
-                consumed_cols,
-                consumed_rows.min(area.height),
-            );
-
-            // Always render half-blocks into the buffer
-            let buf = frame.buffer_mut();
-            image_renderer::render_halfblocks(buf, img_area, &resized);
-
-            // Queue deferred high-res render for Kitty/Sixel
-            if matches!(ctx.protocol, ImageProtocol::Kitty | ImageProtocol::Sixel) {
-                let kitty_b64 = if ctx.protocol == ImageProtocol::Kitty {
-                    ctx.image_cache
-                        .get_encoded_kitty(path, ctx.base_dir, area.width, area.height)
-                        .map(|s| s.to_string())
-                } else {
-                    None
-                };
-                ctx.deferred.push(DeferredImage {
-                    x: img_area.x,
-                    y: img_area.y,
-                    cols: consumed_cols,
-                    rows: consumed_rows.min(area.height),
-                    rgba: resized,
-                    protocol: ctx.protocol,
-                    kitty_b64,
-                });
-            }
-
-            (consumed_rows + 1, Some(img_area))
-        }
+        Block::Heading { level: 1, text } => render_h1(frame, area, text, theme, ctx),
+        Block::Heading { text, .. } => render_heading(frame, area, text, theme),
+        Block::Paragraph { spans } => render_paragraph(frame, area, spans, theme),
+        Block::BulletList { items } => render_bullet_list_static(frame, area, items, theme),
+        Block::NumberedList { items } => render_numbered_list(frame, area, items, theme),
+        Block::Code { lang, code } => render_code(frame, area, lang.as_deref(), code, theme, ctx, block_idx),
+        Block::HorizontalRule => render_horizontal_rule(frame, area, theme),
+        Block::Image { path, alt } => render_image(frame, area, path, alt, theme, ctx),
     }
 }
 
-fn spans_to_line(spans: &[Span], theme: &Theme) -> Line<'static> {
-    let rspans: Vec<RSpan<'static>> = spans
+fn render_h1(
+    frame: &mut Frame,
+    area: Rect,
+    text: &str,
+    theme: &Theme,
+    ctx: &mut RenderCtx,
+) -> BlockRender {
+    let big = ctx.bigtext.render(text, theme.font);
+    let height = big.len() as u16;
+    let rect = Rect::new(area.x, area.y, area.width, height.min(area.height));
+    let max_rows = area.height.min(big.len() as u16);
+    let lines: Vec<Line<'_>> = big
         .iter()
-        .map(|s| match s {
-            Span::Plain(t) => RSpan::styled(t.clone(), theme.body_style()),
-            Span::Bold(t) => RSpan::styled(t.clone(), theme.bold_style()),
-            Span::Italic(t) => RSpan::styled(t.clone(), theme.italic_style()),
-            Span::Code(t) => RSpan::styled(format!("`{t}`"), theme.code_style()),
-        })
+        .take(max_rows as usize)
+        .map(|s| Line::from(RSpan::styled(s.as_str(), theme.h1_style())))
         .collect();
+    frame.render_widget(
+        Paragraph::new(lines),
+        Rect::new(area.x, area.y, area.width, max_rows),
+    );
+    BlockRender::with_entrance(height.saturating_add(1), rect)
+}
+
+fn render_heading(frame: &mut Frame, area: Rect, text: &str, theme: &Theme) -> BlockRender {
+    let rect = Rect::new(area.x, area.y, area.width, 1);
+    let line = Line::from(RSpan::styled(text, theme.heading_style()));
+    frame.render_widget(Paragraph::new(line), rect);
+    BlockRender::with_entrance(2, rect)
+}
+
+fn render_paragraph<'a>(
+    frame: &mut Frame,
+    area: Rect,
+    spans: &'a [Span],
+    theme: &'a Theme,
+) -> BlockRender {
+    let line = spans_to_line(spans, theme);
+    let h = estimate_line_height(&line, area.width);
+    let rect = Rect::new(area.x, area.y, area.width, h);
+    frame.render_widget(Paragraph::new(line).wrap(Wrap { trim: false }), rect);
+    BlockRender::with_entrance(h.saturating_add(1), rect)
+}
+
+fn render_bullet_list_static<'a>(
+    frame: &mut Frame,
+    area: Rect,
+    items: &'a [crate::markdown::ListItem],
+    theme: &'a Theme,
+) -> BlockRender {
+    let mut h = 0u16;
+    for item in items {
+        let lh = render_bullet_item(
+            frame,
+            area,
+            area.y.saturating_add(h),
+            &item.spans,
+            theme,
+        );
+        h = h.saturating_add(lh);
+    }
+    BlockRender::self_entrance(h) // bullets handle their own entrances
+}
+
+fn render_numbered_list<'a>(
+    frame: &mut Frame,
+    area: Rect,
+    items: &'a [crate::markdown::ListItem],
+    theme: &'a Theme,
+) -> BlockRender {
+    let mut h = 0u16;
+    for (i, item) in items.iter().enumerate() {
+        let line = spans_to_line(&item.spans, theme);
+        let prefix = format!("  {}. ", i + 1);
+        let mut spans_vec: Vec<RSpan<'_>> = Vec::with_capacity(line.spans.len() + 1);
+        spans_vec.push(RSpan::styled(prefix, theme.bullet_style()));
+        spans_vec.extend(line.spans);
+        let combined = Line::from(spans_vec);
+        let lh = estimate_line_height(&combined, area.width);
+        frame.render_widget(
+            Paragraph::new(combined).wrap(Wrap { trim: false }),
+            Rect::new(area.x, area.y.saturating_add(h), area.width, lh),
+        );
+        h = h.saturating_add(lh);
+    }
+    BlockRender::self_entrance(h)
+}
+
+fn render_code(
+    frame: &mut Frame,
+    area: Rect,
+    lang: Option<&str>,
+    code: &str,
+    theme: &Theme,
+    ctx: &mut RenderCtx,
+    block_idx: usize,
+) -> BlockRender {
+    let title = lang.unwrap_or("");
+    let highlighted = ctx
+        .highlighter
+        .highlight(code, if title.is_empty() { "txt" } else { title });
+    let total_lines = highlighted.len();
+    let inner_height = total_lines.max(1) as u16;
+    let total_height = inner_height + 2; // borders
+
+    let typewriter_dur = std::time::Duration::from_millis(
+        (total_lines as u64).saturating_mul(50).saturating_add(200),
+    );
+    let entrance = ctx.entrances.get_or_start(
+        ctx.slide_index,
+        block_idx,
+        0,
+        EntranceKind::Typewriter,
+        typewriter_dur,
+    );
+
+    // Build visible lines for the code block. After the typewriter is done,
+    // reuse the cached `Arc<Vec<Line>>` directly instead of rebuilding the vec
+    // frame after frame.
+    let lines: Vec<Line<'static>> = match entrance {
+        None => (*highlighted).clone(),
+        Some(state) => {
+            let (visible_lines, char_frac) =
+                entrance::typewriter_visible(state.progress(), total_lines);
+            let cursor_style = theme.status_accent();
+            let mut out: Vec<Line<'static>> = Vec::with_capacity(inner_height as usize);
+            for (i, hl) in highlighted.iter().enumerate() {
+                if i < visible_lines {
+                    out.push(hl.clone());
+                } else if i == visible_lines && visible_lines < total_lines {
+                    let total_chars: usize =
+                        hl.spans.iter().map(|s| s.content.chars().count()).sum();
+                    let chars_to_show = (char_frac * total_chars as f64) as usize;
+                    out.push(typewriter_partial_line(&hl.spans, chars_to_show, cursor_style));
+                } else {
+                    out.push(Line::from(""));
+                }
+            }
+            out
+        }
+    };
+
+    let code_bg = ctx.highlighter.bg_color().unwrap_or(theme.code_bg);
+    let block_widget = WidgetBlock::default()
+        .borders(Borders::ALL)
+        .border_style(theme.code_border())
+        .title(title);
+    let paragraph = Paragraph::new(lines)
+        .style(Style::default().bg(code_bg))
+        .block(block_widget);
+    let code_rect = Rect::new(area.x, area.y, area.width, total_height.min(area.height));
+    frame.render_widget(paragraph, code_rect);
+    BlockRender::self_entrance(total_height.saturating_add(1)) // code handles its own entrance via typewriter
+}
+
+fn render_horizontal_rule(frame: &mut Frame, area: Rect, theme: &Theme) -> BlockRender {
+    let style = theme.rule_style();
+    let buf = frame.buffer_mut();
+    for x in 0..area.width {
+        if let Some(cell) = buf.cell_mut((area.x.saturating_add(x), area.y)) {
+            cell.set_char('─');
+            cell.set_style(style);
+        }
+    }
+    BlockRender::self_entrance(2)
+}
+
+fn render_image(
+    frame: &mut Frame,
+    area: Rect,
+    path: &str,
+    alt: &str,
+    theme: &Theme,
+    ctx: &mut RenderCtx,
+) -> BlockRender {
+    let resized = match ctx
+        .image_cache
+        .get_resized(path, ctx.base_dir, area.width, area.height)
+    {
+        Some(img) => img.clone(),
+        None => {
+            let label = if alt.is_empty() {
+                format!("[Image: {path}]")
+            } else {
+                format!("[Image: {alt}]")
+            };
+            let line = Line::from(RSpan::styled(label, theme.rule_style()));
+            frame.render_widget(
+                Paragraph::new(line),
+                Rect::new(area.x, area.y, area.width, 1),
+            );
+            return BlockRender::self_entrance(2);
+        }
+    };
+
+    let (px_w, px_h) = resized.dimensions();
+    let consumed_rows = u16::try_from(px_h.div_ceil(2)).unwrap_or(u16::MAX);
+    let consumed_cols = u16::try_from(px_w).unwrap_or(u16::MAX);
+
+    let x_offset = area.width.saturating_sub(consumed_cols) / 2;
+    let img_area = Rect::new(
+        area.x.saturating_add(x_offset),
+        area.y,
+        consumed_cols,
+        consumed_rows.min(area.height),
+    );
+
+    let buf = frame.buffer_mut();
+    image_renderer::render_halfblocks(buf, img_area, &resized);
+
+    if matches!(ctx.protocol, ImageProtocol::Kitty | ImageProtocol::Sixel) {
+        let kitty_b64 = if ctx.protocol == ImageProtocol::Kitty {
+            ctx.image_cache
+                .get_encoded_kitty(path, ctx.base_dir, area.width, area.height)
+                .map(|s| s.to_string())
+        } else {
+            None
+        };
+        ctx.deferred.push(DeferredImage {
+            x: img_area.x,
+            y: img_area.y,
+            cols: consumed_cols,
+            rows: consumed_rows.min(area.height),
+            rgba: resized,
+            protocol: ctx.protocol,
+            kitty_b64,
+        });
+    }
+
+    BlockRender::with_entrance(consumed_rows.saturating_add(1), img_area)
+}
+
+fn spans_to_line<'a>(spans: &'a [Span], theme: &Theme) -> Line<'a> {
+    let mut rspans: Vec<RSpan<'a>> = Vec::with_capacity(spans.len());
+    for s in spans {
+        let span = match s {
+            Span::Plain(t) => RSpan::styled(t.as_str(), theme.body_style()),
+            Span::Bold(t) => RSpan::styled(t.as_str(), theme.bold_style()),
+            Span::Italic(t) => RSpan::styled(t.as_str(), theme.italic_style()),
+            // `Code` still allocates for the `\`...\`` wrapping; pre-baking the
+            // backticks at parse time would remove this last per-frame alloc.
+            Span::Code(t) => RSpan::styled(format!("`{t}`"), theme.code_style()),
+        };
+        rspans.push(span);
+    }
     Line::from(rspans)
+}
+
+/// Build the partially-typed line for the code-block typewriter entrance.
+///
+/// Truncates `spans` to the first `chars_to_show` characters (preserving
+/// per-span styling), then appends a blinking cursor span. Slicing is
+/// byte-accurate via `char_indices` so multi-byte UTF-8 spans don't panic at a
+/// boundary.
+fn typewriter_partial_line(
+    spans: &[RSpan<'static>],
+    chars_to_show: usize,
+    cursor_style: Style,
+) -> Line<'static> {
+    if chars_to_show == 0 {
+        return Line::from(RSpan::styled("▌", cursor_style));
+    }
+    let mut partial: Vec<RSpan<'static>> = Vec::with_capacity(spans.len() + 1);
+    let mut chars_left = chars_to_show;
+    for span in spans {
+        let span_chars = span.content.chars().count();
+        if chars_left >= span_chars {
+            partial.push(span.clone());
+            chars_left -= span_chars;
+            if chars_left == 0 {
+                break;
+            }
+        } else {
+            let byte_idx = span
+                .content
+                .char_indices()
+                .nth(chars_left)
+                .map(|(i, _)| i)
+                .unwrap_or(span.content.len());
+            partial.push(RSpan::styled(
+                span.content[..byte_idx].to_string(),
+                span.style,
+            ));
+            break;
+        }
+    }
+    partial.push(RSpan::styled("▌", cursor_style));
+    Line::from(partial)
 }
 
 fn estimate_line_height(line: &Line, width: u16) -> u16 {
     if width == 0 {
         return 1;
     }
-    let text_width: usize = line.spans.iter().map(|s| s.content.width()).sum();
+    // ASCII fast path: byte-length equals display width, skip the East-Asian-Width walk.
+    let ascii_only = line.spans.iter().all(|s| s.content.is_ascii());
+    let text_width: usize = if ascii_only {
+        line.spans.iter().map(|s| s.content.len()).sum()
+    } else {
+        line.spans.iter().map(|s| s.content.width()).sum()
+    };
     let w = width as usize;
     text_width.div_ceil(w).max(1).min(u16::MAX as usize) as u16
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,8 +1,14 @@
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::PathBuf;
 
 use crate::util::fnv1a;
+
+/// Maximum bytes read from the sync file. The payload is a tiny ASCII
+/// `"<slide> <reveal>"`, so 256 bytes is generous and caps the worst case
+/// where a local attacker swaps the sync file for a symlink to `/dev/zero` or
+/// a multi-GB file.
+const MAX_SYNC_BYTES: u64 = 256;
 
 /// Tiny file-based sync between presenter and follower instances.
 /// The presenter writes `slide_index reveal_count` to a temp file.
@@ -52,7 +58,12 @@ impl SyncFile {
     /// missing, unreadable, malformed (fewer than two whitespace-separated
     /// tokens), or contains values that don't parse as `usize`.
     pub fn read(&self) -> Option<(usize, usize)> {
-        let content = fs::read_to_string(&self.path).ok()?;
+        let mut content = String::with_capacity(64);
+        fs::File::open(&self.path)
+            .ok()?
+            .take(MAX_SYNC_BYTES)
+            .read_to_string(&mut content)
+            .ok()?;
         let mut parts = content.split_whitespace();
         let slide = parts.next()?.parse().ok()?;
         let reveal = parts.next()?.parse().ok()?;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -33,7 +33,10 @@ pub struct Theme {
     pub code_fg: Color,
     pub bold: Color,
     pub italic: Color,
-    pub bullet: &'static str,
+    /// Pre-built `"  <bullet> "` prefix string, populated once at theme
+    /// construction so the renderer can borrow it instead of `format!`-ing
+    /// per bullet per frame.
+    pub bullet_prefix: String,
     pub font: FontStyle,
     /// Slide-to-slide transition used when the deck doesn't override it.
     pub default_transition: TransitionKind,
@@ -51,6 +54,7 @@ impl Theme {
     }
 
     fn hacker() -> Self {
+        let bullet = ">";
         Self {
             bg: Color::Rgb(10, 10, 20),
             fg: Color::Rgb(0, 255, 65),
@@ -61,7 +65,7 @@ impl Theme {
             code_fg: Color::Rgb(200, 200, 200),
             bold: Color::Rgb(255, 255, 100),
             italic: Color::Rgb(150, 150, 255),
-            bullet: ">",
+            bullet_prefix: format!("  {bullet} "),
             font: FontStyle::Block,
             default_transition: TransitionKind::Glitch,
         }
@@ -69,6 +73,7 @@ impl Theme {
 
     fn catppuccin() -> Self {
         // Catppuccin Mocha palette
+        let bullet = "◆";
         Self {
             bg: Color::Rgb(30, 30, 46),         // Base
             fg: Color::Rgb(205, 214, 244),      // Text
@@ -79,13 +84,14 @@ impl Theme {
             code_fg: Color::Rgb(166, 173, 200), // Subtext0
             bold: Color::Rgb(250, 179, 135),    // Peach
             italic: Color::Rgb(180, 190, 254),  // Lavender
-            bullet: "◆",
+            bullet_prefix: format!("  {bullet} "),
             font: FontStyle::Block,
             default_transition: TransitionKind::Dissolve,
         }
     }
 
     fn corporate() -> Self {
+        let bullet = "•";
         Self {
             bg: Color::Rgb(20, 25, 40),
             fg: Color::Rgb(215, 220, 230),
@@ -96,13 +102,14 @@ impl Theme {
             code_fg: Color::Rgb(195, 200, 210),
             bold: Color::Rgb(245, 248, 255),
             italic: Color::Rgb(150, 175, 215),
-            bullet: "•",
+            bullet_prefix: format!("  {bullet} "),
             font: FontStyle::Large,
             default_transition: TransitionKind::Wipe,
         }
     }
 
     fn minimal() -> Self {
+        let bullet = "·";
         Self {
             bg: Color::Reset,
             fg: Color::White,
@@ -113,7 +120,7 @@ impl Theme {
             code_fg: Color::White,
             bold: Color::White,
             italic: Color::Gray,
-            bullet: "·",
+            bullet_prefix: format!("  {bullet} "),
             font: FontStyle::Large,
             default_transition: TransitionKind::Fade,
         }
@@ -190,7 +197,7 @@ mod tests {
     #[test]
     fn hacker_theme_properties() {
         let t = Theme::from_name(&ThemeName::Hacker);
-        assert_eq!(t.bullet, ">");
+        assert_eq!(t.bullet_prefix, "  > ");
         assert!(matches!(t.font, FontStyle::Block));
         assert!(matches!(t.default_transition, TransitionKind::Glitch));
         assert!(matches!(t.bg, Color::Rgb(10, 10, 20)));
@@ -199,7 +206,7 @@ mod tests {
     #[test]
     fn corporate_theme_properties() {
         let t = Theme::from_name(&ThemeName::Corporate);
-        assert_eq!(t.bullet, "•");
+        assert_eq!(t.bullet_prefix, "  • ");
         assert!(matches!(t.font, FontStyle::Large));
         assert!(matches!(t.default_transition, TransitionKind::Wipe));
     }
@@ -207,7 +214,7 @@ mod tests {
     #[test]
     fn catppuccin_theme_properties() {
         let t = Theme::from_name(&ThemeName::Catppuccin);
-        assert_eq!(t.bullet, "◆");
+        assert_eq!(t.bullet_prefix, "  ◆ ");
         assert!(matches!(t.font, FontStyle::Block));
         assert!(matches!(t.default_transition, TransitionKind::Dissolve));
     }
@@ -215,7 +222,7 @@ mod tests {
     #[test]
     fn minimal_theme_properties() {
         let t = Theme::from_name(&ThemeName::Minimal);
-        assert_eq!(t.bullet, "·");
+        assert_eq!(t.bullet_prefix, "  · ");
         assert!(matches!(t.font, FontStyle::Large));
         assert!(matches!(t.default_transition, TransitionKind::Fade));
         assert!(matches!(t.bg, Color::Reset));


### PR DESCRIPTION
Closes #27

## Summary

**Correctness & security** (R3, R5–R11)
- Saturating arithmetic on every `u16` row computation in `render.rs` (release profile has `overflow-checks` off)
- `u16::try_from` for resized image dims instead of `as u16` truncation
- `image_renderer::resolve_and_validate` now sandbox-checks every path (relative *and* absolute) and refuses symlinks via `symlink_metadata`; the `validated` cache (which had a stale-validation hazard) is gone
- 16 MB cap on the deck file read; 256 B cap on the sync-file read (defuses symlink-to-`/dev/zero` DoS)
- Frontmatter end-detection is now line-anchored (only matches `\n---` followed by EOF/`\n`/`\r\n`)
- `Block::HorizontalRule` writes `─` cells directly into the buffer — no `"─".repeat(width)` allocation, no DoS surface for huge terminals
- `saturating_mul` for typewriter duration

**Performance** (R1, R2, R4, R12–R14, R16–R18)
- `Highlighter` and the new `BigtextCache` are rekeyed by `fnv1a` hash, so cache hits no longer allocate a `String` per frame
- `spans_to_line` returns `Line<'a>` borrowing from the parsed slide instead of cloning each span's `String` per frame
- `theme.bullet_prefix` is built once at theme construction; bullet rendering deduplicated into a single `render_bullet_item` helper
- Typewriter extracted into `typewriter_partial_line`; the full-line `String` solely-for-counting allocation is gone, slicing is byte-accurate via `char_indices`
- Code-block path skips the per-frame `Vec<Line>` rebuild when the typewriter is finished — reuses the cached `Arc<Vec<Line>>`
- H1 path uses a `BigtextCache` and emits a single `Paragraph::new(Vec<Line>)` instead of one widget per row
- Animated-background loops fold the `is_empty(...)` check into the `cell_mut` borrow (one buffer lookup per cell instead of two)
- Kitty base64 chunks iterated directly without a `Vec<&[u8]>` collect
- ASCII fast path in `estimate_line_height` skips the East-Asian-Width walk for English text

**Structure** (R19, R21–R26)
- `render_block` split into eight per-arm helpers (`render_h1`, `render_heading`, `render_paragraph`, `render_bullet_list_static`, `render_numbered_list`, `render_code`, `render_horizontal_rule`, `render_image`); dispatcher is now ~12 lines
- `(u16, Option<Rect>)` return replaced by a named `BlockRender { height, entrance_target }` struct
- `render_help`/`render_goto` moved out of `app.rs` into `render::help_overlay`/`goto_overlay`
- `count_bullets`/`initial_reveal` are now `Slide::bullet_count`/`Slide::initial_reveal` methods
- Main-loop tick durations promoted to named `ANIMATION_TICK`/`BACKGROUND_TICK`/`IDLE_TICK` constants
- 8-arg `render_status_bar` replaced by a `StatusBar<'a>` config struct (kills the `#[allow(clippy::too_many_arguments)]` band-aid)
- `EntranceTracker` key widened to `(slide, block, sub)`; cascade items use `sub = item_i + 1`, removing the `block_idx * 10_000 + item_i` magic encoding

11 files changed, +713 / −461 lines.

## Test plan

- [x] `cargo test` (175 tests pass locally)
- [x] `cargo build --release` (clean, 2.7 MB binary)
- [x] `cargo clippy --all-targets` (no warnings)
- [ ] Manual smoke: `cargo run --release -- examples/demo.md` and step through with arrow keys / `:N Enter` / `p` (presenter) / `?` (help) — verify transitions, bullet cascade, code-block typewriter, H1 big-text, image rendering, status bar
- [ ] Manual smoke: presenter+follower sync — `--present` in one terminal, `--follow` in another, verify navigation mirrors and reveal counts stay in step
- [ ] Manual security check: drop a markdown file with `![](./symlink.png)` where `symlink.png -> /etc/passwd`, confirm the image is refused (not silently rendered)

## Deferred for follow-up PRs

- **R15** (hash-keyed image cache): the naive `HashMap<u64, _>` would let a hash collision in `resized` bypass `resolve_and_validate`. Needs a collision-safe design (full-key verification on lookup) before landing.
- **R20** (`background.rs` → `background/{mod,common,percell,scatter}.rs`): mechanical file move; deferred so this diff stays reviewable.