### PR TITLE
Bump version to 0.2.2 (post-release dev)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "deck"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deck"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Terminal presentations with style - animated backgrounds, hacker aesthetic, presenter mode"
 authors = ["Thijs Vos"]


### PR DESCRIPTION
Post-`v0.2.1` housekeeping bump so source builds (e.g. `cargo install --git`) report `0.2.2` rather than the already-released `0.2.1`. The actual `0.2.2` release will land via a future `Release 0.2.2` PR + `v0.2.2` tag once there's content under `[Unreleased]`.

## Summary
- `Cargo.toml`: `version = "0.2.1"` → `"0.2.2"`
- `Cargo.lock`: refreshed (single `deck` package version line)
- No code, no CHANGELOG entry (Unreleased section already in place and empty)

## Test plan
- [x] `cargo check` succeeds with new version
- [x] CI green on all three OSes (no functional changes, should be a near-trivial recompile)