### PR TITLE
Auto-merge Dependabot patch and minor updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Adds a workflow that enables GitHub auto-merge on Dependabot PRs once CI passes. Major version bumps still require manual review.

## Behavior
- Triggers on every `pull_request` event from `dependabot[bot]`
- Uses `dependabot/fetch-metadata@v2` to read the update type
- For `version-update:semver-patch` and `version-update:semver-minor`, runs `gh pr merge --auto --squash`
- Auto-merge respects existing branch protection: GitHub waits until `build (ubuntu-latest|macos-latest|windows-latest)` are all green before merging, then squash-merges and deletes the branch
- Major bumps land in the PR queue without auto-merge — they need a human

## Repo settings already changed
- `allow_auto_merge` flipped to `true` via `gh api PATCH` (was `false`); without this, `gh pr merge --auto` fails

## Currently open Dependabot PRs
- **#20** Bump clap 4.6.0 → 4.6.1 (patch) — would auto-merge
- **#19** Bump softprops/action-gh-release 2 → 3 (major) — manual review

The workflow only fires on new `pull_request` events, so it won't retroactively act on #19/#20. After this PR lands, I can either:
- Comment `@dependabot recreate` on #20 to re-fire the workflow, or
- Run `gh pr merge --auto --squash 20` directly.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: trigger the workflow on #20 (clap patch) and confirm it auto-merges once CI is green
- [ ] Confirm #19 (major softprops bump) is NOT auto-merged